### PR TITLE
Adding a subrouter for the main hostname

### DIFF
--- a/src/user/token.go
+++ b/src/user/token.go
@@ -1,14 +1,15 @@
 package user
 
 import (
-	"net/url"
-	"net/http"
-	"github.com/azukaar/cosmos-server/src/utils"
-	"github.com/golang-jwt/jwt"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
-	"encoding/json"
+
+	"github.com/azukaar/cosmos-server/src/utils"
+	"github.com/golang-jwt/jwt"
 )
 
 func quickLoggout(w http.ResponseWriter, req *http.Request, err error) (utils.User, error) {
@@ -261,7 +262,7 @@ func SendUserToken(w http.ResponseWriter, req *http.Request, user utils.User, mf
 		cookie.Domain = ""
 	} else {
 		if utils.IsValidHostname(reqHostNoPort) {
-			cookie.Domain = "." + "bruj0.net"//reqHostNoPort
+			cookie.Domain = "." + "example.net"//reqHostNoPort
 		} else {
 			utils.Error("UserLogin: Invalid hostname", nil)
 			utils.HTTPError(w, "User Logging Error", http.StatusInternalServerError, "UL001")

--- a/src/utils/middleware.go
+++ b/src/utils/middleware.go
@@ -199,7 +199,7 @@ func EnsureHostname(next http.Handler) http.Handler {
 			http.Error(w, "Bad Request: Invalid hostname.", http.StatusBadRequest)
 			return
 		}
-
+		Debug("middleware EnsureHostname: " + r.Host + "/" + r.URL.Path)
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Hi, I think I found a bug where the paths of the web UI are also handled for the Proxy URLs.
For example, OPNSense has a `/ui` url that was not being handled by the correct reverse proxy but by the redirection of Cosmos.
This patch creates a subrouter that matches request that come to the main hostname, ie `HTTPConfig.Hostname` and is used for  Cosmos URLs so the user URLs are not matched too.