### PR TITLE
Allow Insecure TLS like self-signed certificate for SMTP server

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }

--- a/client/src/pages/config/users/configman.jsx
+++ b/client/src/pages/config/users/configman.jsx
@@ -104,6 +104,7 @@ const ConfigManagement = () => {
           Email_Password: config.EmailConfig.Password,
           Email_From: config.EmailConfig.From,
           Email_UseTLS : config.EmailConfig.UseTLS,
+          Email_AllowInsecureTLS : config.EmailConfig.AllowInsecureTLS,
 
           SkipPruneNetwork: config.DockerConfig.SkipPruneNetwork,
           DefaultDataPath: config.DockerConfig.DefaultDataPath || "/usr",
@@ -155,6 +156,7 @@ const ConfigManagement = () => {
               Password: values.Email_Password,
               From: values.Email_From,
               UseTLS: values.Email_UseTLS,
+              AllowInsecureTLS: values.Email_AllowInsecureTLS,
             },
             DockerConfig: {
               ...config.DockerConfig,
@@ -534,6 +536,15 @@ const ConfigManagement = () => {
                       formik={formik}
                       helperText="SMTP Uses TLS"
                     />
+
+                    {formik.values.Email_UseTLS && (
+                      <CosmosCheckbox
+                        label="Allow Insecure TLS"
+                        name="Email_AllowInsecureTLS"
+                        formik={formik}
+                        helperText="Allow self-signed certificate"
+                      />
+                    )}
                   </>)}
                 </Stack>
               </MainCard>

--- a/src/utils/emails.go
+++ b/src/utils/emails.go
@@ -88,7 +88,7 @@ func SendEmail(recipients []string, subject string, body string) error {
 	auth := smtp.PlainAuth("", config.EmailConfig.Username, config.EmailConfig.Password, config.EmailConfig.Host)
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: false,
+		InsecureSkipVerify: config.EmailConfig.AllowInsecureTLS,
 		ServerName:         config.EmailConfig.Host,
 	}
 

--- a/src/utils/types.go
+++ b/src/utils/types.go
@@ -195,6 +195,7 @@ type EmailConfig struct {
 	Password   string
 	From       string
 	UseTLS		 bool
+	AllowInsecureTLS		 bool
 }
 
 type OpenIDClient struct {


### PR DESCRIPTION
Add an option to allow insecure TLS like self-signed certificat :

TLS disable :
`[ERROR] UserInvite: Error while sending email : unencrypted connection`

TLS enable & TLS Insecure disable :
`[ERROR] UserInvite: Error while sending email : tls: failed to verify certificate: x509: certificate is not valid for any names, but wanted to match protonmail-bridge`

TLS enable & TLS Insecure enable :
`No error and e-mail send`