### PR TITLE
Mitigate XSS and open redirect vulnerability in login page which can lead to full admin/server takeover

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }

--- a/client/src/utils/indexs.js
+++ b/client/src/utils/indexs.js
@@ -43,7 +43,9 @@ export const redirectTo = (url) => {
 }
 
 export const redirectToLocal = (url) => {
-  if(url.startsWith("http://") || url.startsWith("https://")) {
+  let redirectUrl = new URL(url, window.location.href);
+  let currentLocation = window.location;
+  if (redirectUrl.origin != currentLocation.origin){
     throw new Error("URL must be local");
   }
   window.location.href = url;


### PR DESCRIPTION
Current implementation won't allow full url redirection within local origin, and will allow open redirection with href like "//google.com". Example:
https://example.cosmos.com/cosmos-ui/login?redirect=//google.com

This can lead to attackers tricking users/admins to enter their credentials in an attacker-controlled website with the same interface. Or execute Javascript in the context of the users' Cosmos site, example:
https://example.cosmos.com/cosmos-ui/login?redirect=javascript:alert(1)

Using this vulnerability, an attacker can **add himself as an admin** by sending request to the /cosmos/api/users and /cosmos/api/invite invite, allowing for **full Cosmos instance takeover** and **possible server takeover** by running custom docker images. An attacker can also extract the user's password (and username) using this payload:
https://example.cosmos.com/cosmos-ui/login?redirect=javascript:alert(document.getElementById("-password-login").value)

Creating an URL object and comparing redirect url's origin with current origin will ensure the url is indeed an URL and the two share the same protocol, hostname, and port. Example:
- Allowed redirect values: 

1. https://example.cosmos.com
2. //example.cosmos.com
3. /cosmos-ui/monitoring

- Disallowed redirect values:

1. https://google.com
2. //google.com
3. https://example.cosmos.com:8080
4. https://anothersub.cosmos.com
5. http://example.cosmos.com
6. javascript:alert(1)