### PR TITLE
Fix: Wrong file permission for database file store

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "george-radu-cs"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }

--- a/src/utils/db.go
+++ b/src/utils/db.go
@@ -130,7 +130,7 @@ var embeddedClientClose func()
 
 func GetEmbeddedCollection(applicationId string, collection string) (lungo.ICollection, func(), error) {
 	opts := lungo.Options{
-		Store: lungo.NewFileStore(CONFIGFOLDER + "database", 700),
+		Store: lungo.NewFileStore(CONFIGFOLDER + "database", 0700),
 	}
 	
 	name := os.Getenv("MONGODB_NAME"); if name == "" {


### PR DESCRIPTION
## Bug description:

When establishing a database file store, incorrect permission modes are set due to the absence of octal representation.

Assigning the value 700 as the mode does not correspond to the intended (I think) permissions `-rwx------` (700), but rather results in `--w-r-xr--` (254). This occurs because in Go, the `os.FileMode` doesn’t require the value to be provided only in octal format.

Test made to see the difference:

```go
package main

import (
        "os"
)

func main() {
        content := []byte("Hello world!\n")
        os.WriteFile("700", content, 700)
        os.WriteFile("0700", content, 0700)
}
```

and `ls -lah` output showcasing the difference:

```bash
drwxr-xr-x  5 georgeradu  staff   160B Apr  6 21:37 .
drwxr-xr-x  4 georgeradu  staff   128B Apr  6 21:35 ..
-rwx------  1 georgeradu  staff    13B Apr  6 21:37 0700
--w-r-xr--  1 georgeradu  staff    13B Apr  6 21:37 700
-rw-r--r--  1 georgeradu  staff   157B Apr  6 21:37 main.go
```