### PR TITLE
Added option to provide custom dns challenge resolvers

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "SamuelNitsche"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }

--- a/client/src/api/demo.config.json
+++ b/client/src/api/demo.config.json
@@ -13,6 +13,7 @@
 			"GenerateMissingAuthCert": true,
 			"HTTPSCertificateMode": "LETSENCRYPT",
 			"DNSChallengeProvider": "",
+			"DNSChallengeResolver": "",
 			"HTTPPort": "80",
 			"HTTPSPort": "443",
 			"ProxyConfig": {

--- a/client/src/pages/config/users/configman.jsx
+++ b/client/src/pages/config/users/configman.jsx
@@ -102,6 +102,7 @@ const ConfigManagement = () => {
           UseWildcardCertificate: config.HTTPConfig.UseWildcardCertificate,
           HTTPSCertificateMode: config.HTTPConfig.HTTPSCertificateMode,
           DNSChallengeProvider: config.HTTPConfig.DNSChallengeProvider,
+          DNSChallengeResolver: config.HTTPConfig.DNSChallengeResolver,
           DNSChallengeConfig: config.HTTPConfig.DNSChallengeConfig,
           ForceHTTPSCertificateRenewal: config.HTTPConfig.ForceHTTPSCertificateRenewal,
           OverrideWildcardDomains: config.HTTPConfig.OverrideWildcardDomains,
@@ -185,6 +186,7 @@ const ConfigManagement = () => {
               UseWildcardCertificate: values.UseWildcardCertificate,
               HTTPSCertificateMode: values.HTTPSCertificateMode,
               DNSChallengeProvider: values.DNSChallengeProvider,
+              DNSChallengeResolver: values.DNSChallengeResolver,
               DNSChallengeConfig: values.DNSChallengeConfig,
               ForceHTTPSCertificateRenewal: values.ForceHTTPSCertificateRenewal,
               OverrideWildcardDomains: values.OverrideWildcardDomains.replace(/\s/g, ''),
@@ -807,6 +809,20 @@ const ConfigManagement = () => {
                           formik.setFieldValue("ForceHTTPSCertificateRenewal", true);
                         }}
                         label="Email address for Let's Encrypt"
+                        formik={formik}
+                      />
+                    )
+                  }
+
+
+                  {formik.values.HTTPSCertificateMode === "LETSENCRYPT" && (
+                      <CosmosInputText
+                        onChange={(e) => {
+                          formik.setFieldValue("ForceHTTPSCertificateRenewal", true);
+                        }}
+                        label="DNS Server to use when resolving the letsencrypt challenge"
+                        name="DNSChallengeResolver"
+                        configName="DNSChallengeResolver"
                         formik={formik}
                       />
                     )

--- a/client/src/pages/newInstall/newInstall.jsx
+++ b/client/src/pages/newInstall/newInstall.jsx
@@ -296,6 +296,7 @@ const NewInstall = () => {
                     HTTPSCertificateMode: "",
                     UseWildcardCertificate: false,
                     DNSChallengeProvider: '',
+                    DNSChallengeResolver: '',
                     DNSChallengeConfig: {},
                     allowHTTPLocalIPAccess: false,
                     __success: false,
@@ -332,6 +333,7 @@ const NewInstall = () => {
                             TLSCert: values.HTTPSCertificateMode === "PROVIDED" ? values.TLSCert : '',
                             Hostname: values.Hostname,
                             DNSChallengeProvider: values.DNSChallengeProvider,
+                            DNSChallengeResolver: values.DNSChallengeResolver,
                             DNSChallengeConfig: values.DNSChallengeConfig,
                             allowHTTPLocalIPAccess: values.allowHTTPLocalIPAccess,
                         });
@@ -387,6 +389,12 @@ const NewInstall = () => {
                                 name="SSLEmail"
                                 label="Let's Encrypt Email"
                                 placeholder={"email@domain.com"}
+                                formik={formik}
+                            />
+                            <CosmosInputText
+                                name="DNSChallengeResolver"
+                                label="DNS Server to use when resolving the letsencrypt challenge"
+                                placeholder={"1.1.1.1"}
                                 formik={formik}
                             />
                             {formik.values.DNSChallengeProvider && formik.values.DNSChallengeProvider != '' && (

--- a/src/newInstall.go
+++ b/src/newInstall.go
@@ -34,6 +34,7 @@ type NewInstallJSON struct {
 	SSLEmail string `json:"sslEmail",validate:"omitempty,email"`
 	UseWildcardCertificate bool `json:"useWildcardCertificate",validate:"omitempty"`
 	DNSChallengeProvider string `json:"dnsChallengeProvider",validate:"omitempty"`
+	DNSChallengeResolver string `json:"dnsChallengeResolver",validate:"omitempty"`
 	DNSChallengeConfig map[string]string
 	AllowHTTPLocalIPAccess bool `json:"allowHTTPLocalIPAccess",validate:"omitempty"`
 }
@@ -128,6 +129,7 @@ func NewInstallRoute(w http.ResponseWriter, req *http.Request) {
 			newConfig.HTTPConfig.SSLEmail = request.SSLEmail
 			newConfig.HTTPConfig.UseWildcardCertificate = request.UseWildcardCertificate
 			newConfig.HTTPConfig.DNSChallengeProvider = request.DNSChallengeProvider
+			newConfig.HTTPConfig.DNSChallengeResolver = request.DNSChallengeResolver
 			newConfig.HTTPConfig.DNSChallengeConfig = request.DNSChallengeConfig
 			newConfig.HTTPConfig.TLSCert = request.TLSCert
 			newConfig.HTTPConfig.TLSKey = request.TLSKey

--- a/src/utils/certificates.go
+++ b/src/utils/certificates.go
@@ -14,6 +14,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"os"
+	"strings"
 	
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/certificate"
@@ -181,7 +182,13 @@ func DoLetsEncrypt() (string, string) {
 			return "", ""
 		}
 
-		err = client.Challenge.SetDNS01Provider(provider, dns01.addRecursiveNameservers([]string{"1.1.1.1"}))
+		if config.HTTPConfig.DNSChallengeResolver != "" {
+			// Split DNSChallengeResolver by commas to support multiple DNS servers
+			resolvers := strings.Split(config.HTTPConfig.DNSChallengeResolver, ",")
+			err = client.Challenge.SetDNS01Provider(provider, dns01.AddRecursiveNameservers(resolvers))
+		} else {
+			err = client.Challenge.SetDNS01Provider(provider)
+		}		
 	} else {
 		err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", config.HTTPConfig.HTTPPort))
 		if err != nil {

--- a/src/utils/certificates.go
+++ b/src/utils/certificates.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/certificate"
 	"github.com/go-acme/lego/v4/challenge/http01"
+	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/lego"
 	"github.com/go-acme/lego/v4/registration"
 	"github.com/go-acme/lego/v4/challenge/tlsalpn01"
@@ -180,7 +181,7 @@ func DoLetsEncrypt() (string, string) {
 			return "", ""
 		}
 
-		err = client.Challenge.SetDNS01Provider(provider)
+		err = client.Challenge.SetDNS01Provider(provider, dns01.addRecursiveNameservers([]string{"1.1.1.1"}))
 	} else {
 		err = client.Challenge.SetHTTP01Provider(http01.NewProviderServer("", config.HTTPConfig.HTTPPort))
 		if err != nil {

--- a/src/utils/types.go
+++ b/src/utils/types.go
@@ -156,6 +156,7 @@ type HTTPConfig struct {
 	GenerateMissingAuthCert bool
 	HTTPSCertificateMode string
 	DNSChallengeProvider string
+	DNSChallengeResolver string
 	ForceHTTPSCertificateRenewal bool
 	HTTPPort string `validate:"required,containsany=0123456789,min=1,max=6"`
 	HTTPSPort string `validate:"required,containsany=0123456789,min=1,max=6"`


### PR DESCRIPTION
When installing Cosmos Server in internal networks using split dns, letsencrypt dns challenges will most likely fail since the local dns server is used as challenge resolver.

This PR updates the UI and backend to provide an (optional) dns server which is used to resolve the dns challenge.
If the user does not enter a custom server, it will just fall back to the local dns server configured on the machine. Users can also provide multiple servers by separating them using a comma.

Closes https://github.com/azukaar/Cosmos-Server/issues/43