### PR TITLE
feat(dashboard): add basic drag & drop functionality to homescreen

### DIFF
--- a/client/src/pages/home/AppGrid.jsx
+++ b/client/src/pages/home/AppGrid.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Box, Stack } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
+import { Link } from 'react-router-dom';
+import { getFullOrigin } from '../../utils/routes';
+import { ServAppIcon } from '../../utils/servapp-icon';
+import { useDragAndDrop } from '@formkit/drag-and-drop/react';
+
+const AppGrid = ({ config, servApps, routes, coStatus, appColor, appBorder, blockStyle }) => {
+  const validRoutes = routes ? routes.filter(route => !route.HideFromDashboard) : [];
+  const [parentRef, apps] = useDragAndDrop(validRoutes);
+
+  return (
+    <Grid2 container spacing={2} ref={parentRef}>
+      {config && servApps && apps.map((route) => {
+        let skip = route.Mode === 'REDIRECT';
+        let containerName;
+        let container;
+        if (route.Mode === 'SERVAPP') {
+          containerName = route.Target.split(':')[1].slice(2);
+          container = servApps.find((c) => c.Names.includes('/' + containerName));
+          // TOOD: rework, as it prevents users from seeing the apps
+          // if (!container || container.State != "running") {
+          //     skip = true
+          // }
+        }
+
+        if (route.HideFromDashboard) skip = true;
+
+        return (
+          !skip && coStatus && (coStatus.homepage.Expanded ? (
+            <Grid2 xs={12} sm={6} md={4} lg={3} xl={3} xxl={3} key={route.Name}>
+              <Box className='app app-hover' style={{ padding: 25, borderRadius: 5, ...appColor, ...appBorder }}>
+                <Link to={getFullOrigin(route)} target="_blank" style={{ textDecoration: 'none', ...appColor }}>
+                  <Stack direction='row' spacing={2} alignItems='center'>
+                    <ServAppIcon container={container} route={route} className='loading-image' width='70px' />
+                    <div style={{ minWidth: 0 }}>
+                      <h3 style={blockStyle}>{route.Name}</h3>
+                      <p style={blockStyle}>{route.Description}</p>
+                      <p style={{ ...blockStyle, fontSize: '90%', paddingTop: '3px', opacity: '0.45' }}>{route.Target}</p>
+                    </div>
+                  </Stack>
+                </Link>
+              </Box>
+            </Grid2>
+          ) : (
+            <Grid2 xs={6} sm={4} md={3} lg={2} xl={2} xxl={2} key={route.Name}>
+              <Box className='app app-hover' style={{ padding: 25, borderRadius: 5, ...appColor, ...appBorder }}>
+                <Link to={getFullOrigin(route)} target='_blank' style={{ textDecoration: 'none', ...appColor }}>
+                  <Stack direction='column' spacing={2} alignItems='center'>
+                    <ServAppIcon container={container} route={route} className='loading-image' width='70px' />
+                    <div style={{ minWidth: 0 }}>
+                      <h3 style={blockStyle}>{route.Name}</h3>
+                    </div>
+                  </Stack>
+                </Link>
+              </Box>
+            </Grid2>
+          ))
+        );
+      })}
+    </Grid2>
+  );
+};
+
+export default AppGrid;

--- a/client/src/pages/home/AppGrid.jsx
+++ b/client/src/pages/home/AppGrid.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {React, useEffect} from 'react';
 import { Box, Stack } from '@mui/material';
 import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
 import { Link } from 'react-router-dom';
@@ -7,9 +7,15 @@ import { ServAppIcon } from '../../utils/servapp-icon';
 import { useDragAndDrop } from '@formkit/drag-and-drop/react';
 
 const AppGrid = ({ config, servApps, routes, coStatus, appColor, appBorder, blockStyle }) => {
-  const validRoutes = routes ? routes.filter(route => !route.HideFromDashboard) : [];
-  const [parentRef, apps] = useDragAndDrop(validRoutes);
+  const savedOrder = JSON.parse(localStorage.getItem('appOrder')) || [];
+  const initialRoutes = routes ? routes.filter(route => !route.HideFromDashboard) : [];
+  const initialApps = savedOrder.length ? savedOrder : initialRoutes;
+  const [parentRef, apps, setApps] = useDragAndDrop(initialApps);
 
+  useEffect(() => {
+    localStorage.setItem('appOrder', JSON.stringify(apps));
+  }, [apps]);
+  
   return (
     <Grid2 container spacing={2} ref={parentRef}>
       {config && servApps && apps.map((route) => {

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -15,7 +15,7 @@ import { useClientInfos } from "../../utils/hooks";
 import { FormaterForMetric, formatDate } from "../dashboard/components/utils";
 import MiniPlotComponent from "../dashboard/components/mini-plot";
 import Migrate014 from "./migrate014";
-
+import AppGrid from "./AppGrid";
 
 export const HomeBackground = () => {
     const theme = useTheme();
@@ -465,56 +465,13 @@ const HomePage = () => {
                 
                 </>)}
             </>)}
-            
-            {config && servApps && routes.map((route) => {
-                let skip = route.Mode == "REDIRECT";
-                let containerName;
-                let container;
-                if (route.Mode == "SERVAPP") {
-                    containerName = route.Target.split(':')[1].slice(2);
-                    container = servApps.find((c) => c.Names.includes('/' + containerName));
-                    // TOOD: rework, as it prevents users from seeing the apps
-                    // if (!container || container.State != "running") {
-                    //     skip = true
-                    // }
-                }
-                
-                if (route.HideFromDashboard) 
-                    skip = true;
 
-                return !skip && coStatus && (coStatus.homepage.Expanded ?
-                
-                <Grid2 item xs={12} sm={6} md={4} lg={3} xl={3} xxl={3} key={route.Name}>
-                    <Box className='app app-hover' style={{ padding: 25, borderRadius: 5, ...appColor, ...appBorder }}>
-                        <Link to={getFullOrigin(route)} target="_blank" style={{ textDecoration: 'none', ...appColor }}>
-                            <Stack direction="row" spacing={2} alignItems="center">
-                                <ServAppIcon container={container} route={route} className="loading-image" width="70px" />
-                                <div style={{ minWidth: 0 }}>
-                                    <h3 style={blockStyle}>{route.Name}</h3>
-                                    <p style={blockStyle}>{route.Description}</p>
-                                    <p style={{ ...blockStyle, fontSize: '90%', paddingTop: '3px', opacity: '0.45' }}>{route.Target}</p>
-                                </div>
-                            </Stack>
-                        </Link>
-                    </Box>
-                </Grid2>
-                :
-                <Grid2 item xs={6} sm={4} md={3} lg={2} xl={2} xxl={2} key={route.Name}>
-                    <Box className='app app-hover' style={{ padding: 25, borderRadius: 5, ...appColor, ...appBorder }}>
-                        <Link to={getFullOrigin(route)} target="_blank" style={{ textDecoration: 'none', ...appColor }}>
-                            <Stack direction="column" spacing={2} alignItems="center">
-                                <ServAppIcon container={container} route={route} className="loading-image" width="70px" />
-                                <div style={{ minWidth: 0 }}>
-                                    <h3 style={blockStyle}>{route.Name}</h3>
-                                </div>
-                            </Stack>
-                        </Link>
-                    </Box>
-                </Grid2>)
-            })}
-
-            {config && routes.length === 0 && (
-                <Grid2 item xs={12} sm={12} md={12} lg={12} xl={12}>
+            <Grid2 container spacing={2} style={{ zIndex: 2 }}>
+                {config && routes.length > 0 && (
+                    <AppGrid config={config} servApps={servApps} routes={routes} coStatus={coStatus} appColor={appColor} appBorder={appBorder} blockStyle={blockStyle} />
+                )}
+                {config && routes.length === 0 && (
+                <Grid2 xs={12} sm={12} md={12} lg={12} xl={12}>
                     <Box style={{ padding: 10, borderRadius: 5, ...appColor }}>
                         <Stack direction="row" spacing={2} alignItems="center">
                             <div style={{ minWidth: 0 }}>
@@ -524,7 +481,8 @@ const HomePage = () => {
                         </Stack>
                     </Box>
                 </Grid2>
-            )}
+                )}
+            </Grid2>
         </Grid2>
     </Stack>
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "cosmos-server",
-  "version": "0.16.0-unstable16",
+  "version": "0.16.0-unstable22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosmos-server",
-      "version": "0.16.0-unstable16",
+      "version": "0.16.0-unstable22",
       "dependencies": {
         "@ant-design/colors": "^6.0.0",
         "@ant-design/icons": "^4.7.0",
         "@emotion/cache": "^11.10.3",
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
+        "@formkit/drag-and-drop": "^0.1.6",
         "@jamesives/github-sponsors-readme-action": "^1.2.2",
         "@mui/lab": "^5.0.0-alpha.100",
         "@mui/material": "^5.10.6",
@@ -2783,6 +2784,11 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
+    "node_modules/@formkit/drag-and-drop": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@formkit/drag-and-drop/-/drag-and-drop-0.1.6.tgz",
+      "integrity": "sha512-wZyxvk7WTbQ12q8ZGvLoYner1ktBOUf+lCblJT3P0LyqpjGCKTfQMKJtwToKQzJgTbhvow4LBu+yP92Mux321w=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/cache": "^11.10.3",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@formkit/drag-and-drop": "^0.1.6",
     "@jamesives/github-sponsors-readme-action": "^1.2.2",
     "@mui/lab": "^5.0.0-alpha.100",
     "@mui/material": "^5.10.6",


### PR DESCRIPTION
Attempting to add drag and drop functionality to home screen, allowing users to organize their apps however they'd like. I have it working right now, just need to consider how to best handle saving the order so that it persists. LocalStorage is fine for now I guess but eventually it'd be nice to save in the DB via the ProxyRouteConfig object (is there a field in that object I can rely on as a unique key?)

Used [FormKit Drag & Drop](https://drag-and-drop.formkit.com) as it's super freaking lightweight

Partially addresses https://github.com/azukaar/Cosmos-Server/issues/35

![Demo](https://i.imgur.com/S81HKn7.gif)