### PR TITLE
localization: better date handling

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import customParseFormat from 'dayjs/plugin/customParseFormat'; // import this if you need to parse custom formats
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat'; // import this for localized formatting
+import relativeTime from 'dayjs/plugin/relativeTime';
 
 // import i18n (needs to be bundled ;)) 
 import './utils/locales/i18n';
@@ -29,6 +30,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 dayjs.extend(customParseFormat); // if needed
 dayjs.extend(localizedFormat); // if needed
+dayjs.extend(relativeTime);
 
 /* // Dynamically loading the dayjs-locale does not work.
 import(`dayjs/locale/${getLanguage().toLowerCase()}.js`).then(() => dayjs.locale(language.toLowerCase()))

--- a/client/src/layout/MainLayout/Drawer/languages.jsx
+++ b/client/src/layout/MainLayout/Drawer/languages.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Grid, Chip, Stack } from '@mui/material';
 import "./flag.css";
 import { useTranslation } from 'react-i18next';
+import { dayjsLocale } from '../../../utils/locales/i18n';
 
 const languages = [
   { code: 'en', name: 'English (US)', flag: 'us' },
@@ -31,6 +32,7 @@ export const LanguagesSelectModal = ({ open, setOpen }) => {
   const handleLanguageChange = (langCode) => {
     setSelectedLanguage(langCode);
     i18n.changeLanguage(langCode);
+    dayjsLocale(langCode);
   };
 
   const handleClose = () => {

--- a/client/src/layout/MainLayout/Header/HeaderContent/Notification.jsx
+++ b/client/src/layout/MainLayout/Header/HeaderContent/Notification.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 
 // material-ui
 import { useTheme } from '@mui/material/styles';
@@ -20,8 +21,6 @@ import {
     Typography,
     useMediaQuery
 } from '@mui/material';
-import { register, format } from 'timeago.js';
-import de from "timeago.js/lib/lang/de";
 
 // project import
 import MainCard from '../../../../components/MainCard';
@@ -52,7 +51,6 @@ const actionSX = {
 // ==============================|| HEADER CONTENT - NOTIFICATION ||============================== //
 
 const Notification = () => {
-    register('de', de);
     const { t, i18n } = useTranslation();
     const theme = useTheme();
     const matchesXs = useMediaQuery(theme.breakpoints.down('md'));
@@ -256,7 +254,7 @@ const Notification = () => {
                                                 />
                                                 <ListItemSecondaryAction>
                                                     <Typography variant="caption" noWrap>
-                                                        {format(notification.Date, i18n.resolvedLanguage)}
+                                                        {dayjs(notification.Date).fromNow()}
                                                     </Typography>
                                                 </ListItemSecondaryAction>
                                             </ListItemButton>

--- a/client/src/layout/MainLayout/Header/HeaderContent/jobs.jsx
+++ b/client/src/layout/MainLayout/Header/HeaderContent/jobs.jsx
@@ -21,8 +21,7 @@ import {
     useMediaQuery,
     Button
 } from '@mui/material';
-import { register, format } from 'timeago.js';
-import de from "timeago.js/lib/lang/de";
+import dayjs from 'dayjs';
 
 // project import
 import MainCard from '../../../../components/MainCard';
@@ -60,7 +59,6 @@ const getStatus = (job) => {
 }
 
 const Jobs = () => {
-    register('de', de);
     const { t, i18n } = useTranslation();
     const {role} = useClientInfos();
     const isAdmin = role === "2";
@@ -252,7 +250,7 @@ const Jobs = () => {
                                             }}>
                                             <Typography variant="caption" noWrap >
                                                 {job.LastStarted == '0001-01-01T00:00:00Z' ? t('mgmt.scheduler.list.status.neverRan') : (
-                                                    job.Running ? <span><LoadingOutlined />{` `+t('mgmt.cron.list.state.running')+` ${format(job.LastStarted, i18n.resolvedLanguage)}`}</span> : t('mgmt.cron.list.state.lastRan')+` ${format(job.LastRun, i18n.resolvedLanguage)}`
+                                                    job.Running ? <span><LoadingOutlined />{` `+t('mgmt.cron.list.state.running')+` ${dayjs(job.LastStarted).format('L, LT')}`}</span> : t('mgmt.cron.list.state.lastRan')+` ${dayjs(job.LastRun).fromNow()}`
                                                 )}
                                             </Typography>
                                             </ListItemButton>

--- a/client/src/pages/config/users/usermanagement.jsx
+++ b/client/src/pages/config/users/usermanagement.jsx
@@ -23,6 +23,7 @@ import MainCard from '../../../components/MainCard';
 import { useEffect, useState } from 'react';
 import PrettyTableView from '../../../components/tableView/prettyTableView';
 import { Trans, useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 
 const UserManagement = () => {
     const { t } = useTranslation();
@@ -265,14 +266,14 @@ const UserManagement = () => {
                 {
                     title: t('global.createdAt'),
                     screenMin: 'lg',
-                    field: (r) => new Date(r.createdAt).toLocaleString(),
+                    field: (r) => dayjs(new Date(r.createdAt)).format('L, LT'),
                 },
                 {
                     title: t('mgmt.usermgmt.lastLogin'),
                     screenMin: 'lg', 
                     field: (r) => {
                         const hasLastLogin = new Date(r.lastLogin).getTime() > 0;
-                        return <>{hasLastLogin ? new Date(r.lastLogin).toLocaleString() : t('global.never')}</>
+                        return <>{hasLastLogin ? dayjs(new Date(r.lastLogin)).format('L, LT') : t('global.never')}</>
                     },
                 },
                 {

--- a/client/src/pages/cron/jobsManage.jsx
+++ b/client/src/pages/cron/jobsManage.jsx
@@ -18,6 +18,7 @@ import MenuButton from "../../components/MenuButton";
 import JobLogsDialog from "./jobLogs";
 import NewJobDialog from "./newJob";
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 
 const getStatus = (job) => {
   if (job.Running) return 'running';
@@ -130,9 +131,9 @@ export const CronManager = () => {
                 title: t('global.statusTitle'),
                 field: (r) => {
                   return <div style={{maxWidth: '400px'}} >{{
-                    'running': <Alert icon={<LoadingOutlined />} severity={'info'} color={'info'}>{t('mgmt.scheduler.list.status.runningSince')}{r.LastStarted}</Alert>,
-                    'success': <Alert severity={'success'} color={'success'}>{t('mgmt.scheduler.list.status.lastRunFinishedOn')} {r.LastRun}, {t('mgmt.scheduler.list.status.lastRunFinishedOn.duration')} {(new Date(r.LastRun).getTime() - new Date(r.LastStarted).getTime()) / 1000}s</Alert>,
-                    'error': <Alert severity={'error'} color={'error'}>{t('mgmt.scheduler.list.status.lastRunExitedOn')} {r.LastRun}</Alert>,
+                    'running': <Alert icon={<LoadingOutlined />} severity={'info'} color={'info'}>{t('mgmt.scheduler.list.status.runningSince')}{dayjs(new Date(r.LastStarted)).format('L, LT')}</Alert>,
+                    'success': <Alert severity={'success'} color={'success'}>{t('mgmt.scheduler.list.status.lastRunFinishedOn')} {dayjs(new Date(r.LastRun)).format('L, LT')}, {t('mgmt.scheduler.list.status.lastRunFinishedOn.duration')} {(new Date(r.LastRun).getTime() - new Date(r.LastStarted).getTime()) / 1000}s</Alert>,
+                    'error': <Alert severity={'error'} color={'error'}>{t('mgmt.scheduler.list.status.lastRunExitedOn')} {dayjs(new Date(r.LastRun)).format('L, LT')}</Alert>,
                     'never': <Alert severity={'info'} color={'info'}>{t('mgmt.scheduler.list.status.neverRan')}</Alert>
                     
                   }[getStatus(r)]}</div>

--- a/client/src/pages/dashboard/AlertPage.jsx
+++ b/client/src/pages/dashboard/AlertPage.jsx
@@ -30,6 +30,7 @@ import { DeleteButton } from '../../components/delete';
 import { CosmosCheckbox, CosmosFormDivider, CosmosInputText, CosmosSelect } from '../config/users/formShortcuts';
 import { MetricPicker } from './MetricsPicker';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 
 const DisplayOperator = (operator) => {
   switch (operator) {
@@ -482,7 +483,7 @@ const AlertPage = () => {
                 { 
                   title: t('navigation.monitoring.alerts.astTriggeredTitle'),
                   screenMin: 'md',
-                  field: (r) => (r.LastTriggered != "0001-01-01T00:00:00Z") ? new Date(r.LastTriggered).toLocaleString() : t('global.never'),
+                  field: (r) => (r.LastTriggered != "0001-01-01T00:00:00Z") ? dayjs(new Date(r.LastTriggered)).format('L, LT') : t('global.never'),
                 },
                 { 
                   title: t('navigation.monitoring.alerts.actionsTitle'), 

--- a/client/src/pages/dashboard/eventsExplorer.jsx
+++ b/client/src/pages/dashboard/eventsExplorer.jsx
@@ -4,16 +4,14 @@ import * as API from '../../api';
 import { Button, CircularProgress, Stack, TextField } from "@mui/material";
 import { CosmosCollapse, CosmosSelect } from "../config/users/formShortcuts";
 import MainCard from '../../components/MainCard';
-import { register, format } from 'timeago.js';
-import de from "timeago.js/lib/lang/de";
+import dayjs from 'dayjs';
 import { ExclamationOutlined, SettingOutlined } from "@ant-design/icons";
 import { Alert } from "@mui/material";
 import { DownloadFile } from "../../api/downloadButton";
 import { Trans, useTranslation } from 'react-i18next';
 
 const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''}) => {
-	register('de', de);
-	const { t, i18n } = useTranslation();
+	const { t } = useTranslation();
 	const [events, setEvents] = useState([]);
 	const [loading, setLoading] = useState(true);
 	const [search, setSearch] = useState(initSearch);
@@ -174,7 +172,7 @@ const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''
 									event.level == "debug" ? <SettingOutlined /> : event.level == "important" ? <ExclamationOutlined /> : undefined
 								}>
 									<div style={{fontWeight: 'bold', fontSize: '120%'}}>{event.label}</div>
-									<div>{(new Date(event.date)).toLocaleString()} - {format(event.date, i18n.resolvedLanguage)}</div>
+									<div>{(new Date(event.date)).toLocaleString()} - {dayjs(event.date).fromNow()}</div>
 									<div>{event.eventId} - {event.object}</div>
 								</Alert>}>
 								<div style={{overflow: 'auto'}}>

--- a/client/src/pages/dashboard/eventsExplorer.jsx
+++ b/client/src/pages/dashboard/eventsExplorer.jsx
@@ -160,7 +160,7 @@ const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''
 			</Stack>
 			<div>
 				{!loading &&
-					<Trans i18nKey="navigation.monitoring.events.eventsFound" count={total} values={{from: from.toLocaleString(), to: to.toLocaleString()}}/>
+					<Trans i18nKey="navigation.monitoring.events.eventsFound" count={total} values={{from: dayjs(from).format('L, LT'), to: dayjs(to).format('L, LT')}}/>
 				}
 			</div>
 			<div>
@@ -172,7 +172,7 @@ const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''
 									event.level == "debug" ? <SettingOutlined /> : event.level == "important" ? <ExclamationOutlined /> : undefined
 								}>
 									<div style={{fontWeight: 'bold', fontSize: '120%'}}>{event.label}</div>
-									<div>{(new Date(event.date)).toLocaleString()} - {dayjs(event.date).fromNow()}</div>
+									<div>{dayjs(event.date).format('L, LT')} - {dayjs(event.date).fromNow()}</div>
 									<div>{event.eventId} - {event.object}</div>
 								</Alert>}>
 								<div style={{overflow: 'auto'}}>

--- a/client/src/pages/servapps/networks.jsx
+++ b/client/src/pages/servapps/networks.jsx
@@ -7,6 +7,7 @@ import * as API from '../../api';
 import PrettyTableView from '../../components/tableView/prettyTableView';
 import NewNetworkButton from './createNetwork';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 
 export const NetworksColumns = (theme, isDark, t) => [
   {
@@ -42,7 +43,7 @@ export const NetworksColumns = (theme, isDark, t) => [
   {
     title: t('global.createdAt'),
     screenMin: 'lg',
-    field: (r) => r.Created ? new Date(r.Created).toLocaleString() : '-',
+    field: (r) => r.Created ? dayjs(new Date(r.Created)).format('L, LT') : '-',
   },
 ];
 

--- a/client/src/pages/servapps/volumes.jsx
+++ b/client/src/pages/servapps/volumes.jsx
@@ -15,6 +15,7 @@ import HostChip from '../../components/hostChip';
 import PrettyTableView from '../../components/tableView/prettyTableView';
 import NewVolumeButton from './createVolumes';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 
 const VolumeManagementList = () => {
     const { t } = useTranslation();
@@ -76,7 +77,7 @@ const VolumeManagementList = () => {
                         {
                             title: t('global.createdAt'),
                             screenMin: 'lg', 
-                            field: (r) => new Date(r.CreatedAt).toLocaleString(),
+                            field: (r) => dayjs(new Date(r.CreatedAt)).format('L, LT'),
                         },
                         {
                             title: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "semver-compare": "^1.0.0",
         "simplebar": "^5.3.8",
         "simplebar-react": "^2.4.1",
-        "timeago.js": "^4.0.2",
         "typescript": "4.8.3",
         "vite": "^4.2.0",
         "web-vitals": "^3.0.2",
@@ -10562,11 +10561,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "node_modules/timeago.js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
-      "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w=="
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "semver-compare": "^1.0.0",
     "simplebar": "^5.3.8",
     "simplebar-react": "^2.4.1",
-    "timeago.js": "^4.0.2",
     "typescript": "4.8.3",
     "vite": "^4.2.0",
     "web-vitals": "^3.0.2",


### PR DESCRIPTION
This PR improves 3 things concerning date-localization:
- add dayjs to locale-switcher
- remove usage of timeago.js in favor of day.js (already present, supports timeago and localisation)
- switch from native Date-function .tolocaleString() to day.js (supports locale-switcher)