### PR TITLE
Set Content-Type header for oauth2 user response

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson", "RaidMax"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }

--- a/src/authorizationserver/oauth2_user.go
+++ b/src/authorizationserver/oauth2_user.go
@@ -91,5 +91,6 @@ func userInfosEndpoint(rw http.ResponseWriter, req *http.Request) {
 		baseToken.Role = "user"
 	}
 	
+	rw.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	json.NewEncoder(rw).Encode(baseToken)
 }


### PR DESCRIPTION
Adds json content-type header to oauth2 user response. 
Some SSO clients have validation checks for this header and will fail to parse the response (even if it is valid) without the content-type header.