### PR TITLE
rework IsLocalIP using standard library functions

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson", "RaidMax"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson", "RaidMax", "r41d"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }


### PR DESCRIPTION
* this time against unstable branch
* don't hardcode IPs but rather use the standard library for checking loopback and private networks
* one of the old checks with `strings.HasPrefix(ip, "172.")` was too broad because the private range is `172.16/12` and not `172/8`
* addtional private networks are added
