### PR TITLE
Add trusted proxies

### DIFF
--- a/client/src/pages/config/users/configman.jsx
+++ b/client/src/pages/config/users/configman.jsx
@@ -114,6 +114,7 @@ const ConfigManagement = () => {
           GenerateMissingAuthCert: config.HTTPConfig.GenerateMissingAuthCert,
           HTTPPort: config.HTTPConfig.HTTPPort,
           HTTPSPort: config.HTTPConfig.HTTPSPort,
+          TrustedProxies: config.HTTPConfig.TrustedProxies && config.HTTPConfig.TrustedProxies.join(', '),
           SSLEmail: config.HTTPConfig.SSLEmail,
           UseWildcardCertificate: config.HTTPConfig.UseWildcardCertificate,
           HTTPSCertificateMode: config.HTTPConfig.HTTPSCertificateMode,
@@ -214,6 +215,8 @@ const ConfigManagement = () => {
               AllowSearchEngine: values.AllowSearchEngine,
               AllowHTTPLocalIPAccess: values.AllowHTTPLocalIPAccess,
               PublishMDNS: values.PublishMDNS,
+              TrustedProxies: (values.TrustedProxies && values.TrustedProxies != "") ?
+                values.TrustedProxies.split(',').map((x) => x.trim()) : [],
             },
             EmailConfig: {
               ...config.EmailConfig,
@@ -654,6 +657,18 @@ const ConfigManagement = () => {
                           {formik.errors.HTTPSPort}
                         </FormHelperText>
                       )}
+                    </Stack>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Stack spacing={1}>
+                      <Alert severity="info">
+                        {t('mgmt.config.http.trustedProxiesInput.trustedProxiesHelperText')}<br />
+                      </Alert>
+                      <CosmosInputText
+                        label={t('mgmt.config.http.trustedProxiesInput.trustedProxiesLabel')}
+                        name="TrustedProxies"
+                        formik={formik}
+                      />
                     </Stack>
                   </Grid>
                   <Grid item xs={12}>

--- a/client/src/utils/locales/en/translation.json
+++ b/client/src/utils/locales/en/translation.json
@@ -192,6 +192,8 @@
 	"mgmt.config.http.hostnameInput.HostnameLabel": "Hostname: This will be used to restrict access to your Cosmos Server (Your IP, or your domain name)",
 	"mgmt.config.http.hostnameInput.HostnameValidation": "Hostname is required",
 	"mgmt.config.http.publishMDNSCheckbox": "This allows you to publish your server on your local network using mDNS. This means all your .local domains will be available on your local network with no additional config.",
+	"mgmt.config.http.trustedProxiesInput.trustedProxiesLabel": "Trusted proxies allow X-Forwarded-For from IP/IP range.",
+	"mgmt.config.http.trustedProxiesInput.trustedProxiesHelperText": "Use this setting when you have an upstream proxy server to avoid it being blocked by Shield. IPs or IP ranges separated by commas.",
 	"mgmt.config.email.notifyLoginCheckbox.notifyLoginLabel": "Notify Users upon Successful Login",
 	"mgmt.config.proxy.noRoutesConfiguredText": "No routes configured.",
 	"mgmt.config.proxy.originTitle": "Origin",

--- a/client/src/utils/locales/fr/translation.json
+++ b/client/src/utils/locales/fr/translation.json
@@ -174,6 +174,8 @@
   "mgmt.config.http.hostnameInput.HostnameLabel": "Nom d'hôte : Cela sera utilisé pour restreindre l'accès à votre serveur Cosmos (Votre IP, ou votre nom de domaine)",
   "mgmt.config.http.hostnameInput.HostnameValidation": "Le nom d'hôte est obligatoire",
   "mgmt.config.http.publishMDNSCheckbox": "Cela vous permet de publier votre serveur sur votre réseau local en utilisant mDNS. Cela signifie que tous vos domaines .local seront disponibles sur votre réseau local sans configuration supplémentaire.",
+  "mgmt.config.http.trustedProxiesInput.trustedProxiesLabel": "Trusted proxies allow X-Forwarded-For from IP/IP range.",
+	"mgmt.config.http.trustedProxiesInput.trustedProxiesHelperText": "Use this setting when you have an upstream proxy server to avoid it being blocked by Shield. IPs or IP ranges separated by commas.",
   "mgmt.config.email.notifyLoginCheckbox.notifyLoginLabel": "Notifier les utilisateurs en cas de connexion réussie",
   "mgmt.config.proxy.noRoutesConfiguredText": "Aucune route configurée.",
   "mgmt.config.proxy.originTitle": "Origine",

--- a/src/httpServer.go
+++ b/src/httpServer.go
@@ -431,6 +431,8 @@ func InitServer() *mux.Router {
 
 	router := mux.NewRouter().StrictSlash(true)
 	
+	router.Use(utils.ClientRealIP)
+	
 	router.Use(utils.BlockBannedIPs)
 
 	router.Use(utils.Logger)

--- a/src/proxy/shield.go
+++ b/src/proxy/shield.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/azukaar/cosmos-server/src/utils"
 	"github.com/azukaar/cosmos-server/src/metrics"
@@ -296,14 +297,19 @@ func calculateLowestExhaustedPercentage(policy utils.SmartShieldPolicy, userCons
 func GetClientID(r *http.Request, route utils.ProxyRouteConfig) string {
 	// when using Docker we need to get the real IP
 	remoteAddr, _ := utils.SplitIP(r.RemoteAddr)
-	UseForwardedFor := utils.GetMainConfig().HTTPConfig.UseForwardedFor
-	isTunneledIp := constellation.GetDeviceIp(route.TunnelVia) == remoteAddr
-	isConstIP := utils.IsConstellationIP(remoteAddr)
-	isConstTokenValid := constellation.CheckConstellationToken(r) == nil
+	useForwardedForHeader := false
+	if r.Header.Get("x-forwarded-for") != "" {
+		useForwardedForHeader = utils.IsTrustedProxy(remoteAddr)
+		if !useForwardedForHeader {
+			isTunneledIp := constellation.GetDeviceIp(route.TunnelVia) == remoteAddr
+			isConstIP := utils.IsConstellationIP(remoteAddr)
+			isConstTokenValid := constellation.CheckConstellationToken(r) == nil
+			useForwardedForHeader = isTunneledIp && isConstIP && isConstTokenValid
+		}
+	}
 
-	if (UseForwardedFor && r.Header.Get("x-forwarded-for") != "") || 
-		 (isTunneledIp && isConstIP && isConstTokenValid) {
-		ip, _ := utils.SplitIP(r.Header.Get("x-forwarded-for"))
+	if useForwardedForHeader {
+		ip, _ := utils.SplitIP(strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-For"), ",")[0]))
 		utils.Debug("SmartShield: Getting forwarded client ID " + ip)
 		return ip
 	} else {

--- a/src/utils/types.go
+++ b/src/utils/types.go
@@ -184,6 +184,7 @@ type HTTPConfig struct {
 	UseForwardedFor bool
 	AllowSearchEngine bool
 	PublishMDNS bool
+	TrustedProxies []string
 } 
 
 const (

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -801,11 +801,12 @@ func DownloadFileToLocation(path, url string) error {
 }
 
 func GetClientIP(req *http.Request) string {
-	/*ip := req.Header.Get("X-Forwarded-For")
-	if ip == "" {
-		ip = req.RemoteAddr
-	}*/
-	return req.RemoteAddr
+	remoteAddr, _ := SplitIP(req.RemoteAddr)
+
+	if req.Header.Get("x-forwarded-for") != "" && IsTrustedProxy(remoteAddr) {
+		remoteAddr, _ = SplitIP(strings.TrimSpace(strings.Split(req.Header.Get("X-Forwarded-For"), ",")[0]))
+	}
+	return remoteAddr
 }
 
 func IsDomain(domain string) bool {
@@ -928,6 +929,15 @@ func IsConstellationIP(ip string) bool {
 	}
 
 	return false 
+}
+
+func IsTrustedProxy(ip string) bool {
+	for _, trustedProxy := range GetMainConfig().HTTPConfig.TrustedProxies {
+		if isInRange, _ := IPInRange(ip, trustedProxy); isInRange {
+			return true
+		}
+	}
+	return false
 }
 
 func SplitIP(ipPort string) (string, string) {


### PR DESCRIPTION
# Add trusted proxies

This pull request adds a parameter allowing the specification of a list of trusted proxies for which the X-Forwarded-For header will be used. This enhances security and management of IP addresses from trusted proxies.

## Changes Made:
client/src/pages/config/users/configman.jsx :
- Added the TrustedProxies field in the configuration form.
- Handled the list of trusted proxies to generate a comma-separated string.
- Added logic to process the conversion of the string into an IP address list.

client/src/utils/locales/en/translation.json :
- Added labels and helper texts for trusted proxies in English.

client/src/utils/locales/fr/translation.json :
- Added labels and helper texts for trusted proxies in French.

src/httpServer.go :
- Updated server configuration to include the ClientRealIP middleware.

src/proxy/shield.go :
- Updated logic to use IP addresses from X-Forwarded-For headers only if they come from trusted proxies.

src/utils/middleware.go :
- Updated ClientRealIP middleware to use trusted proxies.
- Updated middlewares BlockBannedIPs, BlockByCountryMiddleware, BlockPostWithoutReferer, EnsureHostname, and EnsureHostnameCosmosAPI to use IP addresses from trusted proxies.

src/utils/types.go :
- Added TrustedProxies field to the HTTP configuration.

src/utils/utils.go :
- Added IsTrustedProxy function to check if an IP address is in the trusted proxies list.
- Updated GetClientIP function to use X-Forwarded-For only if it comes from a trusted proxy.

> [!NOTE]
> I accidentally deleted PR #339, so here we go again