### PR TITLE
[FEAT] Add Exec form to "command" and "entrypoint" in cosmos compose.

### DIFF
--- a/api-docs/swagger.yaml
+++ b/api-docs/swagger.yaml
@@ -328,7 +328,13 @@ definitions:
           type: string
         type: array
       command:
-        type: string
+        oneOf:
+          - type: string
+            description: Shell-form command line (tokenized into args, quotes respected)
+          - type: array
+            description: Exec-form command arguments (passed verbatim)
+            items:
+              type: string
       container_name:
         type: string
       cpu_shares:
@@ -356,7 +362,13 @@ definitions:
       domainname:
         type: string
       entrypoint:
-        type: string
+        oneOf:
+          - type: string
+            description: Shell-form entrypoint (tokenized into args, quotes respected)
+          - type: array
+            description: Exec-form entrypoint arguments (passed verbatim)
+            items:
+              type: string
       environment:
         items:
           type: string

--- a/api-docs/swagger.yaml
+++ b/api-docs/swagger.yaml
@@ -334,7 +334,13 @@ definitions:
           type: string
         type: array
       command:
-        type: string
+        oneOf:
+          - type: string
+            description: Shell-form command line (tokenized into args, quotes respected)
+          - type: array
+            description: Exec-form command arguments (passed verbatim)
+            items:
+              type: string
       container_name:
         type: string
       cpu_shares:
@@ -362,7 +368,13 @@ definitions:
       domainname:
         type: string
       entrypoint:
-        type: string
+        oneOf:
+          - type: string
+            description: Shell-form entrypoint (tokenized into args, quotes respected)
+          - type: array
+            description: Exec-form entrypoint arguments (passed verbatim)
+            items:
+              type: string
       environment:
         items:
           type: string

--- a/client/src/pages/servapps/containers/docker-compose.jsx
+++ b/client/src/pages/servapps/containers/docker-compose.jsx
@@ -227,11 +227,20 @@ const convertDockerCompose = (config, serviceName, dockerCompose, setYmlError) =
               }
             }
 
-            // convert command 
-            if (doc.services[key].command) {
-              if (typeof doc.services[key].command !== 'string') {
-                doc.services[key].command = doc.services[key].command.join(' ');
-              }
+            // convert command: pass through docker-compose's native form. A string is
+            // shell-form (server tokenizes into args), an array is exec-form
+            // (server uses it verbatim). Previously arrays were force-joined into
+            // a single string, which both broke exec-form commands and mangled
+            // shell quoting. Normalize stray non-string/non-array scalar values to
+            // a string, but leave genuine arrays intact.
+            if (doc.services[key].command && typeof doc.services[key].command !== 'string' && !Array.isArray(doc.services[key].command)) {
+                doc.services[key].command = String(doc.services[key].command);
+            }
+
+            // entrypoint follows the same rules as command (docker-compose allows a
+            // string for shell-form or an array for exec-form).
+            if (doc.services[key].entrypoint && typeof doc.services[key].entrypoint !== 'string' && !Array.isArray(doc.services[key].entrypoint)) {
+                doc.services[key].entrypoint = String(doc.services[key].entrypoint);
             }
 
             // convert DependsOn

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -61,8 +61,8 @@ type ContainerCreateRequestContainer struct {
 	Tty            bool              `json:"tty,omitempty"`
 	StdinOpen      bool              `json:"stdin_open,omitempty"`
 
-	Command string `json:"command,omitempty"`
-	Entrypoint string `json:"entrypoint,omitempty"`
+	Command strslice.StrSlice `json:"command,omitempty"`
+	Entrypoint strslice.StrSlice `json:"entrypoint,omitempty"`
 	Runtime string `json:"runtime,omitempty"`
 	WorkingDir string `json:"working_dir,omitempty"`
 	User string `json:"user,omitempty"`
@@ -140,6 +140,94 @@ type DockerServiceCreateRollback struct {
 	Name string `json:"name"`
 	// was: container old settings
 	Was doctype.ContainerJSON `json:"was"`
+}
+
+// NormalizeCmdArgs converts a user-supplied command/entrypoint into the argv form
+// the Docker SDK expects (containerConfig.Cmd / containerConfig.Entrypoint, both
+// strslice.StrSlice). It accepts both upstream Docker forms:
+//
+//   - Exec form: an array of arguments, e.g. ["/bin/sh", "-c", "echo hi"]. Used verbatim.
+//   - Shell form: a single whitespace-separated string, e.g. "echo hi". Tokenized into
+//     arguments while respecting single/double quotes (consistent with docker-compose).
+//
+// A single-element array is treated as shell form so legacy Cosmos configs/backups that
+// stored a plain command string continue to work unchanged.
+func NormalizeCmdArgs(input strslice.StrSlice) strslice.StrSlice {
+	if input == nil || len(input) == 0 {
+		return strslice.StrSlice{}
+	}
+
+	// Exec form: multiple explicit arguments, pass through untouched.
+	if len(input) > 1 {
+		return input
+	}
+
+	// A single element could be a shell-form command line (e.g. "npm run dev")
+	// OR the JSON decoder wrapping a bare string/array-of-one. Tokenize it so a
+	// quoted argument ("echo 'hello world'") stays a single argv element.
+	cmdline := strings.TrimSpace(input[0])
+	if cmdline == "" {
+		// Empty input: keep Cmd/Entrypoint unset (nil) so the image's own
+		// CMD/ENTRYPOINT is used, exactly like the pre-StrsSlice behaviour.
+		return nil
+	}
+	args := strings.Fields(cmdline)
+	if strings.Contains(cmdline, "'") || strings.Contains(cmdline, "\"") || strings.Contains(cmdline, "\\") {
+		args = SplitCommandArgs(cmdline)
+	}
+	return strslice.StrSlice(args)
+}
+
+// SplitCommandArgs tokenizes a shell command string into individual arguments,
+// treating single ('...') and double ("...") quotes as grouping delimiters. This
+// mirrors how docker-compose parses shell-form CMD/ENTRYPOINT values.
+func SplitCommandArgs(cmdline string) []string {
+	var b strings.Builder
+	var args []string
+	inArg := false
+	quote := ""
+	i := 0
+	for i < len(cmdline) {
+		c := cmdline[i : i+1]
+		if quote != "" {
+			if c == quote {
+				quote = ""
+			} else {
+				b.WriteString(c)
+			}
+			i++
+			continue
+		}
+		if c == "'" || c == "\"" {
+			quote = c
+			inArg = true
+			i++
+			continue
+		}
+		if c == " " || c == "\t" || c == "\n" {
+			if inArg {
+				args = append(args, b.String())
+				b = strings.Builder{}
+				inArg = false
+			}
+			i++
+			continue
+		}
+		// backslash escape inside shell form
+		if c == "\\" && i+1 < len(cmdline) {
+			b.WriteString(cmdline[i+1 : i+2])
+			inArg = true
+			i += 2
+			continue
+		}
+		b.WriteString(c)
+		inArg = true
+		i++
+	}
+	if inArg {
+		args = append(args, b.String())
+	}
+	return args
 }
 
 func Rollback(actions []DockerServiceCreateRollback , OnLog func(string)) {
@@ -540,12 +628,16 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			}
 		}
 		
-		if container.Command != "" {
-			containerConfig.Cmd = strings.Fields(container.Command)
+		if container.Command != nil && len(container.Command) > 0 {
+			if cmdArgs := NormalizeCmdArgs(container.Command); cmdArgs != nil && len(cmdArgs) > 0 {
+				containerConfig.Cmd = cmdArgs
+			}
 		}
 
-		if container.Entrypoint != "" {
-			containerConfig.Entrypoint = strslice.StrSlice(strings.Fields(container.Entrypoint))
+		if container.Entrypoint != nil && len(container.Entrypoint) > 0 {
+			if entryArgs := NormalizeCmdArgs(container.Entrypoint); entryArgs != nil && len(entryArgs) > 0 {
+				containerConfig.Entrypoint = entryArgs
+			}
 		}
 
 		// For Expose / Ports

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -62,8 +62,8 @@ type ContainerCreateRequestContainer struct {
 	Tty            bool              `json:"tty,omitempty"`
 	StdinOpen      bool              `json:"stdin_open,omitempty"`
 
-	Command string `json:"command,omitempty"`
-	Entrypoint string `json:"entrypoint,omitempty"`
+	Command strslice.StrSlice `json:"command,omitempty"`
+	Entrypoint strslice.StrSlice `json:"entrypoint,omitempty"`
 	Runtime string `json:"runtime,omitempty"`
 	WorkingDir string `json:"working_dir,omitempty"`
 	User string `json:"user,omitempty"`
@@ -141,6 +141,94 @@ type DockerServiceCreateRollback struct {
 	Name string `json:"name"`
 	// was: container old settings
 	Was doctype.ContainerJSON `json:"was"`
+}
+
+// NormalizeCmdArgs converts a user-supplied command/entrypoint into the argv form
+// the Docker SDK expects (containerConfig.Cmd / containerConfig.Entrypoint, both
+// strslice.StrSlice). It accepts both upstream Docker forms:
+//
+//   - Exec form: an array of arguments, e.g. ["/bin/sh", "-c", "echo hi"]. Used verbatim.
+//   - Shell form: a single whitespace-separated string, e.g. "echo hi". Tokenized into
+//     arguments while respecting single/double quotes (consistent with docker-compose).
+//
+// A single-element array is treated as shell form so legacy Cosmos configs/backups that
+// stored a plain command string continue to work unchanged.
+func NormalizeCmdArgs(input strslice.StrSlice) strslice.StrSlice {
+	if input == nil || len(input) == 0 {
+		return strslice.StrSlice{}
+	}
+
+	// Exec form: multiple explicit arguments, pass through untouched.
+	if len(input) > 1 {
+		return input
+	}
+
+	// A single element could be a shell-form command line (e.g. "npm run dev")
+	// OR the JSON decoder wrapping a bare string/array-of-one. Tokenize it so a
+	// quoted argument ("echo 'hello world'") stays a single argv element.
+	cmdline := strings.TrimSpace(input[0])
+	if cmdline == "" {
+		// Empty input: keep Cmd/Entrypoint unset (nil) so the image's own
+		// CMD/ENTRYPOINT is used, exactly like the pre-StrsSlice behaviour.
+		return nil
+	}
+	args := strings.Fields(cmdline)
+	if strings.Contains(cmdline, "'") || strings.Contains(cmdline, "\"") || strings.Contains(cmdline, "\\") {
+		args = SplitCommandArgs(cmdline)
+	}
+	return strslice.StrSlice(args)
+}
+
+// SplitCommandArgs tokenizes a shell command string into individual arguments,
+// treating single ('...') and double ("...") quotes as grouping delimiters. This
+// mirrors how docker-compose parses shell-form CMD/ENTRYPOINT values.
+func SplitCommandArgs(cmdline string) []string {
+	var b strings.Builder
+	var args []string
+	inArg := false
+	quote := ""
+	i := 0
+	for i < len(cmdline) {
+		c := cmdline[i : i+1]
+		if quote != "" {
+			if c == quote {
+				quote = ""
+			} else {
+				b.WriteString(c)
+			}
+			i++
+			continue
+		}
+		if c == "'" || c == "\"" {
+			quote = c
+			inArg = true
+			i++
+			continue
+		}
+		if c == " " || c == "\t" || c == "\n" {
+			if inArg {
+				args = append(args, b.String())
+				b = strings.Builder{}
+				inArg = false
+			}
+			i++
+			continue
+		}
+		// backslash escape inside shell form
+		if c == "\\" && i+1 < len(cmdline) {
+			b.WriteString(cmdline[i+1 : i+2])
+			inArg = true
+			i += 2
+			continue
+		}
+		b.WriteString(c)
+		inArg = true
+		i++
+	}
+	if inArg {
+		args = append(args, b.String())
+	}
+	return args
 }
 
 func Rollback(actions []DockerServiceCreateRollback , OnLog func(string)) {
@@ -541,12 +629,16 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			}
 		}
 		
-		if container.Command != "" {
-			containerConfig.Cmd = strings.Fields(container.Command)
+		if container.Command != nil && len(container.Command) > 0 {
+			if cmdArgs := NormalizeCmdArgs(container.Command); cmdArgs != nil && len(cmdArgs) > 0 {
+				containerConfig.Cmd = cmdArgs
+			}
 		}
 
-		if container.Entrypoint != "" {
-			containerConfig.Entrypoint = strslice.StrSlice(strings.Fields(container.Entrypoint))
+		if container.Entrypoint != nil && len(container.Entrypoint) > 0 {
+			if entryArgs := NormalizeCmdArgs(container.Entrypoint); entryArgs != nil && len(entryArgs) > 0 {
+				containerConfig.Entrypoint = entryArgs
+			}
 		}
 
 		// For Expose / Ports

--- a/src/docker/export.go
+++ b/src/docker/export.go
@@ -16,6 +16,7 @@ import (
 
 	conttype "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+	strslice "github.com/docker/docker/api/types/strslice"
 )
 
 var ExportError = "" 
@@ -35,8 +36,8 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 			Image:        detailedInfo.Config.Image,
 			Environment:  detailedInfo.Config.Env,
 			Labels:       detailedInfo.Config.Labels,
-			Command:      strings.Join(detailedInfo.Config.Cmd, " "),
-			Entrypoint:   strings.Join(detailedInfo.Config.Entrypoint, " "),
+			Command:      strslice.StrSlice(detailedInfo.Config.Cmd),
+			Entrypoint:   strslice.StrSlice(detailedInfo.Config.Entrypoint),
 			WorkingDir:   detailedInfo.Config.WorkingDir,
 			User:         detailedInfo.Config.User,
 			Tty:          detailedInfo.Config.Tty,


### PR DESCRIPTION
This small change in the code allows for usage of the **exec form** in `CMD` and `ENTRYPOINT` commands.

The **exec form** is functionally superior to the **shell form** allowing for more complex executions including f.e. the `&&` and `||` operators and more.
Meanwhile it can still behave as the **shell form** does, when appending `[ "/bin/sh", "-c" ]` to the beginning of the **exec form** array.
[Docker Documentation](https://docs.docker.com/reference/dockerfile/#entrypoint)

Specific table comparing the different usages of exec and shell form in docker:
<img width="832" height="254" alt="grafik" src="https://github.com/user-attachments/assets/084267ba-f6f4-4c39-af36-71b5877e067f" />

I have tested it against several images of my own market and on existing machines and it seems to work flawlessly. Existing templates using shell form (string) are converted to an array containing a single string element.