### PR TITLE
Fix HTTP to HTTPS redirect

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson", "RaidMax", "r41d","moham96"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson", "RaidMax", "r41d","moham96", "Acid-base"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }

--- a/src/httpServer.go
+++ b/src/httpServer.go
@@ -36,6 +36,25 @@ var serverPortHTTPS = ""
 var HTTPServer *http.Server
 var HTTPServer2 *http.Server
 
+func httpsRedirectHandler(httpsPort string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostname := r.Host
+		if host, _, err := net.SplitHostPort(r.Host); err == nil {
+			hostname = host
+		} else if strings.HasPrefix(hostname, "[") && strings.HasSuffix(hostname, "]") {
+			hostname = strings.TrimPrefix(strings.TrimSuffix(hostname, "]"), "[")
+		}
+
+		if httpsPort != "" && httpsPort != "443" {
+			hostname = net.JoinHostPort(hostname, httpsPort)
+		} else if strings.Contains(hostname, ":") {
+			hostname = "[" + hostname + "]"
+		}
+
+		http.Redirect(w, r, "https://"+hostname+r.URL.RequestURI(), http.StatusPermanentRedirect)
+	})
+}
+
 func startHTTPServer(router *mux.Router) error {
 	HTTPServer2 = nil
 	HTTPServer = &http.Server{
@@ -122,15 +141,13 @@ func startHTTPSServer(router *mux.Router) error {
 		
 	// redirect http to https
 	go (func () {
-		httpRouter := mux.NewRouter()
-
 		HTTPServer2 = &http.Server{
 			Addr: "0.0.0.0:" + serverPortHTTP,
 			ReadTimeout: 0,
 			ReadHeaderTimeout: 10 * time.Second,
 			WriteTimeout: 0,
 			IdleTimeout: 30 * time.Second,
-			Handler: httpRouter,
+			Handler: httpsRedirectHandler(serverPortHTTPS),
 			DisableGeneralOptionsHandler: true,
 		}
 

--- a/src/httpServer_test.go
+++ b/src/httpServer_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPSRedirectHandler(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestURL   string
+		httpsPort    string
+		wantLocation string
+	}{
+		{
+			name:         "standard HTTPS port",
+			requestURL:   "http://example.test/dashboard?tab=routes",
+			httpsPort:    "443",
+			wantLocation: "https://example.test/dashboard?tab=routes",
+		},
+		{
+			name:         "strip HTTP port from hostname",
+			requestURL:   "http://example.test:80/cosmos/api/status",
+			httpsPort:    "443",
+			wantLocation: "https://example.test/cosmos/api/status",
+		},
+		{
+			name:         "configured nonstandard HTTPS port",
+			requestURL:   "http://example.test:8080/files/report.txt?download=1",
+			httpsPort:    "8443",
+			wantLocation: "https://example.test:8443/files/report.txt?download=1",
+		},
+		{
+			name:         "IPv6 hostname",
+			requestURL:   "http://[2001:db8::1]/cosmos-ui/",
+			httpsPort:    "443",
+			wantLocation: "https://[2001:db8::1]/cosmos-ui/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.requestURL, nil)
+			res := httptest.NewRecorder()
+
+			httpsRedirectHandler(tt.httpsPort).ServeHTTP(res, req)
+
+			if res.Code != http.StatusPermanentRedirect {
+				t.Fatalf("status = %d, want %d", res.Code, http.StatusPermanentRedirect)
+			}
+			if got := res.Header().Get("Location"); got != tt.wantLocation {
+				t.Fatalf("Location = %q, want %q", got, tt.wantLocation)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- serve a real HTTP-to-HTTPS redirect instead of an empty router that returns 404
- preserve the requested hostname, path, and query string
- support IPv6 hostnames and configured non-standard HTTPS ports
- use `308 Permanent Redirect` so non-GET requests keep their method and body

## Reproduction

With HTTPS enabled, a request to the HTTP listener currently returns a bare 404:

```console
$ curl -i http://cosmos.example/
HTTP/1.1 404 Not Found

404 page not found
```

`startHTTPSServer` creates a new `mux.Router` for port 80 but does not register any routes or redirect handlers on it.

## Test

```console
go test ./src -run '^TestHTTPSRedirectHandler$' -count=1
```

Result: **pass** with Go 1.25.0.

The regression test covers the standard HTTPS port, removal of an incoming HTTP port, a configured non-standard HTTPS port, IPv6 hostnames, and preservation of paths and query strings.
