### PR TITLE
cla: sign CLA (add VHStark as contributor)

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,4 +1,4 @@
 {
-  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson", "RaidMax", "r41d","moham96"],
+  "contributors": ["azukaar", "jwr1", "Jogai", "InterN0te", "catmandx", "revam", "Kawanaao", "davis4acca", "george-radu-cs", "BearTS", "lilkidsuave", "ryan-schubert", "madejackson", "RaidMax", "r41d","moham96", "VHStark"],
   "message": "We require contributors to sign our [Contributor License Agreement](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md). In order for us to review and merge your code, add yourself to the .clabot file as contributor, as a way of signing the CLA."
 }


### PR DESCRIPTION
Signs the Cosmos CLA by adding `VHStark` to the `.clabot` contributors list, per [cla.md](https://github.com/azukaar/Cosmos-Server/blob/master/cla.md).

Prerequisite for #551 — the cla-bot validates against `.clabot` on `master`, so the sign-up needs to land here separately before it can green-light the feature PR.