### PR TITLE
Fix: Ensure Let's Encrypt DNS CleanUp is called on graceful shutdown

### DIFF
--- a/src/storage/rclone.go
+++ b/src/storage/rclone.go
@@ -482,7 +482,7 @@ func setupSignalHandler() {
 		utils.Log(fmt.Sprintf("[RemoteStorage] Received signal %v, unmounting all storages...", sig))
 		rcloneUnmountAll()
 		utils.Log("[RemoteStorage] All storages unmounted, exiting...")
-		os.Exit(0)
+		utils.RestartServer(0)
 	}()
 }
 

--- a/src/utils/certificates.go
+++ b/src/utils/certificates.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"sync"
 	"crypto/x509"
 	"encoding/pem"
 	"math/big"
@@ -27,6 +28,39 @@ import (
 	"github.com/go-acme/lego/v5/providers/dns"
 	"github.com/go-acme/lego/v5/challenge/dns01"
 )
+
+var (
+	letsEncryptMu     sync.Mutex
+	letsEncryptCancel context.CancelFunc
+	letsEncryptWG     sync.WaitGroup
+)
+
+// CancelAndCleanUpLetsEncrypt safely cancels any ongoing Let's Encrypt challenge and waits for DNS cleanup.
+func CancelAndCleanUpLetsEncrypt(timeout time.Duration) {
+	letsEncryptMu.Lock()
+	cancel := letsEncryptCancel
+	letsEncryptMu.Unlock()
+
+	if cancel == nil {
+		return
+	}
+
+	Log("Cancelling Let's Encrypt process to allow DNS CleanUp...")
+	cancel()
+
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		letsEncryptWG.Wait()
+	}()
+
+	select {
+	case <-c:
+		Log("Let's Encrypt cleanup finished.")
+	case <-time.After(timeout):
+		Log("Let's Encrypt cleanup timed out.")
+	}
+}
 
 type CAConfig struct {
 	Certificate *x509.Certificate
@@ -228,7 +262,19 @@ func (u *CertUser) GetPrivateKey() crypto.Signer {
 func DoLetsEncrypt() (string, string) {
 	config := GetMainConfig()
 	LetsEncryptErrors = []string{}
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	letsEncryptMu.Lock()
+	letsEncryptCancel = cancel
+	letsEncryptMu.Unlock()
+
+	letsEncryptWG.Add(1)
+	defer func() {
+		letsEncryptMu.Lock()
+		letsEncryptCancel = nil
+		letsEncryptMu.Unlock()
+		letsEncryptWG.Done()
+	}()
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -478,6 +478,10 @@ func SaveConfigTofile(config Config) {
 func RestartServer(code int) {
 	Log("Restarting server...")
 	WaitForAllJobs()
+
+	// Cancel any ongoing Let's Encrypt processes so they can CleanUp!
+	CancelAndCleanUpLetsEncrypt(15 * time.Second)
+
 	if StopAllRCloneProcess != nil {
 		StopAllRCloneProcess(false)
 	}


### PR DESCRIPTION
**Description**
Currently, when Cosmos Server is restarted or receives a SIGTERM while `go-acme/lego` is in the middle of solving a DNS-01 challenge, the process terminates immediately. This interrupts the DNS provider's cleanup routine, leaving orphaned `_acme-challenge` TXT records behind in the DNS zone. 

For domains with Wildcard A records (e.g., `*.example.com`), these orphaned `_acme-challenge.subdomain` TXT records cause the subdomain to become an "Empty Non-Terminal". This breaks the wildcard resolution for that specific subdomain, effectively taking it offline until the TXT records are manually deleted.

**Fix**
This PR implements a graceful shutdown for the Let's Encrypt certificate generation process:
1. Added a `context.Context` to the `lego.Obtain()` call in `utils/certificates.go`.
2. Implemented a `sync.WaitGroup` (`LetsEncryptWG`) to track ongoing Let's Encrypt operations.
3. Updated `RestartServer()` (and hooked it into `storage/rclone.go`'s SIGTERM handler) to call the context's cancel function.
4. Added a wait step that gives `go-acme/lego` up to 15 seconds to safely perform its DNS provider `CleanUp()` API calls and remove the `_acme-challenge` records before the container actually exits.

**Testing**
Tested with IONOS API. Triggered a forced renewal for 50+ domains and issued `systemctl restart cosmos` while it was waiting for propagation. All TXT records were successfully deleted before the server restarted, leaving no orphans behind.
