### PR TITLE
fix zram/swap shown under disks

### DIFF
--- a/src/storage/disks.go
+++ b/src/storage/disks.go
@@ -44,7 +44,7 @@ func ListDisks() ([]BlockDevice, error) {
 
 	filteredDevices := make([]lsblk.BlockDevice, 0)
 	for _, device := range devices {
-		if strings.HasPrefix(device.MountPoint, "/snap") {
+		if strings.HasPrefix(device.MountPoint, "/snap") || device.MountPoint == "[SWAP]" {
 			continue
 		}
 		filteredDevices = append(filteredDevices, device)


### PR DESCRIPTION
When using ZRAM on OpenWrt, df lists a swap partition with mountpoint `[SWAP]` which gets listed in Cosmos under Storage -> Disks.

This PR filters out disks that have mountpoint `[SWAP]`

Before:
<img width="1178" height="668" alt="image" src="https://github.com/user-attachments/assets/3a4cdb9b-4a84-458d-b0d9-379da5d2df99" />



After:
<img width="1201" height="452" alt="image" src="https://github.com/user-attachments/assets/1f8efa34-25fb-4eb7-ba0f-da37ead24419" />
