### PR TITLE
fix Display oidc route-Name (remove __route_)

### DIFF
--- a/client/src/pages/authentication/openid.jsx
+++ b/client/src/pages/authentication/openid.jsx
@@ -50,13 +50,13 @@ const OpenID = () => {
     <Grid container spacing={3}>
       <Grid item xs={12}>
         <Stack spacing={2}>
-          <Typography variant="h3">{t('oidc.title', {client_id: client_id})}</Typography>
+          <Typography variant="h3">{t('oidc.title', {client_id: client_id.replace("__route_", "")})}</Typography>
           <Stack direction="row" justifyContent="space-between" alignItems="baseline" spacing={2} style={{
             alignItems: 'center',
           }}>
             <img src={icon} alt={'icon'} width="64px" />
             <div>
-              <Trans i18nKey='oidc.loginDescription' values={{client_id: client_id}} />
+              <Trans i18nKey='oidc.loginDescription' values={{client_id: client_id.replace("__route_", "")}} />
             </div>
           </Stack>
         </Stack>


### PR DESCRIPTION
small visual fix for OpenID Client name that removes the `__route_ `-prefix:

Before:
<img width="529" height="512" alt="image" src="https://github.com/user-attachments/assets/6e804c0d-2339-4bf3-882b-12c6494f2fab" />

After:
<img width="535" height="486" alt="image" src="https://github.com/user-attachments/assets/e6012e88-5fe9-4969-96bd-44316a474249" />
