### PR TITLE
fix(mounts): normalize volume field casing to lowercase with backward compatibility

### DIFF
--- a/client/src/pages/servapps/containers/docker-compose.jsx
+++ b/client/src/pages/servapps/containers/docker-compose.jsx
@@ -1027,9 +1027,9 @@ const DockerComposeImport = ({ refresh, dockerComposeInit, installerInit, defaul
                           Binds: [],
                           Mounts: value.volumes && Object.keys(value.volumes).map(k => {
                             return {
-                              Type: value.volumes[k].type || (k.startsWith('/') ? t('mgmt.servapps.newContainer.volumes.bindInput') : t('global.volume')),
-                              Source: value.volumes[k].source || "",
-                              Target: value.volumes[k].target || "",
+                              type: value.volumes[k].type || (k.startsWith('/') ? 'bind' : 'volume'),
+                              source: value.volumes[k].source || "",
+                              target: value.volumes[k].target || "",
                             }
                           }) || [],
                         }
@@ -1041,10 +1041,10 @@ const DockerComposeImport = ({ refresh, dockerComposeInit, installerInit, defaul
                             ...overrides[value.container_name],
                             volumes: containerInfo.volumes.map((v, k) => {
                               return {
-                                type: v.Type,
-                                source: v.Source,
-                                target: v.Target,
-                                existing: v.Type == 'volume' && volumes.find(v2 => v2.Source === v.Name),
+                                type: v.type,
+                                source: v.source,
+                                target: v.target,
+                                existing: v.type == 'volume' && volumes.find(v2 => v2.source === v.name),
                               }
                             })
                           }

--- a/client/src/pages/servapps/containers/newServiceForm.jsx
+++ b/client/src/pages/servapps/containers/newServiceForm.jsx
@@ -294,9 +294,9 @@ const NewDockerServiceForm = () => {
                 ...containerInfo.HostConfig,
                 Mounts: values.volumes.map((volume) => {
                   return {
-                    Type: volume.Type,
-                    Source: volume.Source,
-                    Target: volume.Target,
+                    type: volume.type,
+                    source: volume.source,
+                    target: volume.target,
                   };
                 }),
               },

--- a/client/src/pages/servapps/containers/volumes.jsx
+++ b/client/src/pages/servapps/containers/volumes.jsx
@@ -71,13 +71,17 @@ const VolumeContainerSetup = ({
   const initialValues = useMemo(() => {
     return {
       volumes: [
-        ...(containerInfo.HostConfig.Mounts || []),
+        ...(containerInfo.HostConfig.Mounts || []).map((m) => ({
+          type: m.Type || m.type,
+          source: m.Source || m.source,
+          target: m.Target || m.target || m.Destination || m.destination,
+        })),
         ...(containerInfo.HostConfig.Binds || []).map((bind) => {
           const [source, destination, mode] = bind.split(":");
           return {
-            Type: "bind",
-            Source: source,
-            Target: destination,
+            type: "bind",
+            source: source,
+            target: destination,
           };
         }),
       ],
@@ -89,7 +93,7 @@ const VolumeContainerSetup = ({
       const errors = {};
       // check unique
       const volumes = values.volumes.map((volume) => {
-        return `${volume.Target}`;
+        return `${volume.target}`;
       });
       const unique = [...new Set(volumes)];
       if (unique.length !== volumes.length) {
@@ -106,11 +110,10 @@ const VolumeContainerSetup = ({
       if (newContainer) return;
       setSubmitting(true);
       const realvalues = {
-        Volumes: values.volumes.map((volume) => ({
-          Type: volume.Type,
-          Source: volume.Source,
-          Target: volume.Target,
-          ReadOnly: false, // TODO: add support for this
+        volumes: values.volumes.map((volume) => ({
+          type: volume.type,
+          source: volume.source,
+          target: volume.target,
         })),
       };
       return API.docker
@@ -167,12 +170,12 @@ const VolumeContainerSetup = ({
                                 formik.setFieldValue("volumes", [
                                   ...formik.values.volumes,
                                   {
-                                    Type: "volume",
-                                    Name: "",
-                                    Driver: "local",
-                                    Source: "",
-                                    Destination: "",
-                                    RW: true,
+                                    type: "volume",
+                                    name: "",
+                                    driver: "local",
+                                    source: "",
+                                    destination: "",
+                                    rw: true,
                                   },
                                 ]);
                               }}
@@ -195,12 +198,12 @@ const VolumeContainerSetup = ({
                                 >
                                   <TextField
                                     className="px-2 my-2"
-                                    disabled={frozenVolumes.includes(r.Source)}
+                                    disabled={frozenVolumes.includes(r.source)}
                                     variant="outlined"
                                     id="Type"
                                     select
-                                    value={r.Type}
-                                    name={`volumes[${k}].Type`}
+                                    value={r.type}
+                                    name={`volumes[${k}].type`}
                                     onChange={formik.handleChange}
                                   >
                                     <MenuItem value="bind">{t('mgmt.servapps.newContainer.volumes.bindInput')}</MenuItem>
@@ -222,26 +225,26 @@ const VolumeContainerSetup = ({
                                     maxWidth: "300px",
                                   }}
                                 >
-                                  {r.Type == "bind" ? (
+                                  {r.type == "bind" ? (
                                     <Stack direction={"row"} spacing={2}>
                                     <FilePickerButton onPick={(path) => {
                                       if(path)
-                                        formik.setFieldValue(`volumes[${k}].Source`, path);
+                                        formik.setFieldValue(`volumes[${k}].source`, path);
                                     }} size="150%" select="folder" />
                                     <TextField
                                       className="px-2 my-2"
                                       variant="outlined"
-                                      name={`volumes[${k}].Source`}
+                                      name={`volumes[${k}].source`}
                                       id="Source"
                                       disabled={frozenVolumes.includes(
-                                        r.Source
+                                        r.source
                                       )}
                                       style={{ minWidth: "200px" }}
-                                      value={r.Source}
+                                      value={r.source}
                                       onChange={formik.handleChange}
                                     />
                                     </Stack>
-                                  ) : r.Type == "tmpfs" ? (
+                                  ) : r.type == "tmpfs" ? (
                                     <TextField
                                       className="px-2 my-2"
                                       variant="outlined"
@@ -253,22 +256,22 @@ const VolumeContainerSetup = ({
                                     <TextField
                                       className="px-2 my-2"
                                       variant="outlined"
-                                      name={`volumes[${k}].Source`}
+                                      name={`volumes[${k}].source`}
                                       id="Source"
                                       disabled={frozenVolumes.includes(
-                                        r.Source
+                                        r.source
                                       )}
                                       select
                                       style={{ minWidth: "200px" }}
-                                      value={r.Source}
+                                      value={r.source}
                                       onChange={formik.handleChange}
                                     >
                                       {[...volumes, r].map((volume) => (
                                         <MenuItem
                                           key={volume.Id || "last"}
-                                          value={volume.Name || volume.Source}
+                                          value={volume.Name || volume.source}
                                         >
-                                          {volume.Name || volume.Source}
+                                          {volume.Name || volume.source}
                                         </MenuItem>
                                       ))}
                                     </TextField>
@@ -291,11 +294,11 @@ const VolumeContainerSetup = ({
                                   <TextField
                                     className="px-2 my-2"
                                     variant="outlined"
-                                    name={`volumes[${k}].Target`}
+                                    name={`volumes[${k}].target`}
                                     id="Target"
-                                    disabled={frozenVolumes.includes(r.Source)}
+                                    disabled={frozenVolumes.includes(r.source)}
                                     style={{ minWidth: "200px" }}
-                                    value={r.Target}
+                                    value={r.target}
                                     onChange={formik.handleChange}
                                   />
                                 </div>
@@ -309,7 +312,7 @@ const VolumeContainerSetup = ({
                                     <PermissionGuard permission={PERM_RESOURCES}><Button
                                     variant="outlined"
                                     color="primary"
-                                    disabled={frozenVolumes.includes(r.Source)}
+                                    disabled={frozenVolumes.includes(r.source)}
                                     onClick={() => {
                                       const newVolumes = [
                                         ...formik.values.volumes,
@@ -326,7 +329,7 @@ const VolumeContainerSetup = ({
                                   >
                                     {t('global.unmount')}
                                   </Button></PermissionGuard>
-                                  {!newContainer && containerInfo.Name && (r.Target ? <BackupDialog preName={`${containerInfo.Name.replace("/", "").replace("/", "-")}-${r.Target.replace("/", "").replaceAll("/", "_")}`} preSource={formatSource(r.Source)} refresh={() => setTimeout(refreshAll, 1500)} /> : null)}
+                                  {!newContainer && containerInfo.Name && (r.target ? <BackupDialog preName={`${containerInfo.Name.replace("/", "").replace("/", "-")}-${r.target.replace("/", "").replaceAll("/", "_")}`} preSource={formatSource(r.source)} refresh={() => setTimeout(refreshAll, 1500)} /> : null)}
                                   </Stack>
                                 );
                               },
@@ -386,7 +389,7 @@ const VolumeContainerSetup = ({
       }}>
         {containerInfo && containerInfo.HostConfig && containerInfo.HostConfig.Mounts && <MainCard title={t('mgmt.backup.backups')}>
           <Backups pathFilters={
-            containerInfo.HostConfig.Mounts.map((r) => formatSource(r.Source)).filter(Boolean)
+            containerInfo.HostConfig.Mounts.map((r) => formatSource(r.source || r.Source)).filter(Boolean)
           } />
         </MainCard>}
       </div>}

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
-	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	conttype "github.com/docker/docker/api/types/container"
 	doctype "github.com/docker/docker/api/types"
@@ -50,7 +49,7 @@ type ContainerCreateRequestContainer struct {
 	Environment []string `json:"environment"`
 	Labels      map[string]string `json:"labels"`
 	Ports       []string          `json:"ports"`
-	Volumes     []mount.Mount          `json:"volumes"`
+	Volumes     []CosmosMount          `json:"volumes"`
 	Networks    map[string]ContainerCreateRequestServiceNetwork `json:"networks"`
 	Routes 			[]utils.ProxyRouteConfig          `json:"routes"`
 	Links       []string  `json:"links,omitempty"`
@@ -646,7 +645,7 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 
 		// Create missing folders for bind mounts
 		for _, newmount := range container.Volumes {
-			if newmount.Type == mount.TypeBind {
+			if newmount.Type == "bind" {
 				newSource := newmount.Source
 
 				if utils.IsInsideContainer {
@@ -735,7 +734,7 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 
 		hostConfig := &conttype.HostConfig{
 			PortBindings: PortBindings,
-			Mounts:       container.Volumes,
+			Mounts:       ToDockerMountSlice(container.Volumes),
 			RestartPolicy: conttype.RestartPolicy{
 				Name: conttype.RestartPolicyMode(container.RestartPolicy),
 			},

--- a/src/docker/api_updateContainer.go
+++ b/src/docker/api_updateContainer.go
@@ -11,7 +11,6 @@ import (
 	containerType "github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
-	"github.com/docker/docker/api/types/mount"
 	"github.com/gorilla/mux"
 )
 
@@ -23,7 +22,7 @@ type ContainerForm struct {
 	Devices        []string          `json:"devices"`
 	Labels         map[string]string `json:"labels"`
 	PortBindings   nat.PortMap       `json:"portBindings"`
-	Volumes        []mount.Mount     `json:"Volumes"`
+	Volumes        []CosmosMount     `json:"volumes"`
 	// we make this a int so that we can ignore 0
 	Interactive    int               `json:"interactive"`
 	NetworkMode 	 string           `json:"networkMode"`
@@ -127,7 +126,7 @@ func UpdateContainerRoute(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 		if(form.Volumes != nil) {
-			container.HostConfig.Mounts = form.Volumes
+			container.HostConfig.Mounts = ToDockerMountSlice(form.Volumes)
 			container.HostConfig.Binds = []string{}
 		}
 		if(form.Interactive != 0) {

--- a/src/docker/checkPorts.go
+++ b/src/docker/checkPorts.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"errors"
 	"runtime"
-	mountType "github.com/docker/docker/api/types/mount"
 )
 
 func isPortAvailable(port string) bool {
@@ -149,9 +148,9 @@ func UpdatePorts(finalPorts []string) error {
 			"DOCKER_HOST=" + os.Getenv("DOCKER_HOST"),
 			"PORTS=" + strings.Join(finalPorts, ","),
 		},
-		Volumes: []mountType.Mount{
+		Volumes: []CosmosMount{
 			{
-				Type: mountType.TypeBind,
+				Type: "bind",
 				Source: "/var/run/docker.sock",
 				Target: "/var/run/docker.sock",
 			},

--- a/src/docker/docker.go
+++ b/src/docker/docker.go
@@ -23,7 +23,6 @@ import (
 	// natting "github.com/docker/go-connections/nat"
 	"github.com/docker/docker/api/types/container"
 	conttype "github.com/docker/docker/api/types/container"
-	mountType "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types"
 )
 
@@ -154,7 +153,7 @@ func EditContainer(oldContainerID string, newConfig types.ContainerJSON, noLock 
 		// create missing folders
 		
 		for _, newmount := range newConfig.HostConfig.Mounts {
-			if newmount.Type == mountType.TypeBind {
+			if newmount.Type == "bind" {
 				newSource := newmount.Source
 
 				if utils.IsInsideContainer {
@@ -681,9 +680,9 @@ func SelfAction(action string) error {
 			"ACTION=" + action,
 			"DOCKER_HOST=" + os.Getenv("DOCKER_HOST"),
 		},
-		Volumes: []mountType.Mount{
+		Volumes: []CosmosMount{
 			{
-				Type: mountType.TypeBind,
+				Type: "bind",
 				Source: "/var/run/docker.sock",
 				Target: "/var/run/docker.sock",
 			},

--- a/src/docker/export.go
+++ b/src/docker/export.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types"
 
 	conttype "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 )
 
 var ExportError = "" 
@@ -96,23 +95,21 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 			}(),
 
 			// Volumes
-			Volumes: func() []mount.Mount {
-					mounts := []mount.Mount{}
+			Volumes: func() []CosmosMount {
+					mounts := []CosmosMount{}
 					for _, m := range detailedInfo.Mounts {
-						mount := mount.Mount{
-							Type:        m.Type,
-							Source:      m.Source,
-							Target:      m.Destination,
-							ReadOnly:    !m.RW,
-							// Consistency: mount.Consistency(m.Consistency),
+						cm := CosmosMount{
+							Type:   string(m.Type),
+							Source: m.Source,
+							Target: m.Destination,
 						}
 
 						if m.Type == "volume" {
 							nodata := strings.Split(strings.TrimSuffix(m.Source, "/_data"), "/")
-							mount.Source = nodata[len(nodata)-1]
+							cm.Source = nodata[len(nodata)-1]
 						}
 
-						mounts = append(mounts, mount)
+						mounts = append(mounts, cm)
 					}
 					return mounts
 			}(),

--- a/src/docker/mount.go
+++ b/src/docker/mount.go
@@ -1,0 +1,93 @@
+package docker
+
+import (
+	"encoding/json"
+
+	"github.com/docker/docker/api/types/mount"
+)
+
+// CosmosMount mirrors mount.Mount but uses lowercase JSON tags to match
+// the Docker Compose specification and the rest of Cosmos's API conventions.
+// It also supports reading legacy uppercase fields for backward compatibility.
+type CosmosMount struct {
+	Type   string `json:"type"`
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+// UnmarshalJSON implements a compatibility layer that accepts both lowercase
+// (new canonical) and uppercase (legacy Docker SDK) field names.
+func (c *CosmosMount) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*c = CosmosMount{}
+
+	// Helper: try lowercase key first, then uppercase fallback
+	getStr := func(low, up string) string {
+		if v, ok := raw[low]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+		if v, ok := raw[up]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+		return ""
+	}
+
+	c.Type = getStr("type", "Type")
+	c.Source = getStr("source", "Source")
+	c.Target = getStr("target", "Target")
+	return nil
+}
+
+// ToDockerMount converts a CosmosMount into the Docker SDK mount.Mount type.
+func (c CosmosMount) ToDockerMount() mount.Mount {
+	return mount.Mount{
+		Type:   mount.Type(c.Type),
+		Source: c.Source,
+		Target: c.Target,
+	}
+}
+
+// ToDockerMountSlice converts a slice of CosmosMount into a slice of mount.Mount.
+func ToDockerMountSlice(c []CosmosMount) []mount.Mount {
+	m := make([]mount.Mount, len(c))
+	for i, mount := range c {
+		m[i] = mount.ToDockerMount()
+	}
+	return m
+}
+
+// IsBindMount returns true if the CosmosMount type is a bind mount.
+func (c CosmosMount) IsBindMount() bool {
+	return c.Type == string(mount.TypeBind)
+}
+
+// IsVolumeMount returns true if the CosmosMount type is a volume mount.
+func (c CosmosMount) IsVolumeMount() bool {
+	return c.Type == string(mount.TypeVolume)
+}
+
+// FromDockerMount converts a Docker SDK mount.Mount into a CosmosMount.
+func FromDockerMount(m mount.Mount) CosmosMount {
+	return CosmosMount{
+		Type:   string(m.Type),
+		Source: m.Source,
+		Target: m.Target,
+	}
+}
+
+// FromDockerMountSlice converts a slice of mount.Mount into a slice of CosmosMount.
+func FromDockerMountSlice(mounts []mount.Mount) []CosmosMount {
+	c := make([]CosmosMount, len(mounts))
+	for i, m := range mounts {
+		c[i] = FromDockerMount(m)
+	}
+	return c
+}


### PR DESCRIPTION
## Disclaimer

This PR was written with the help of Plurality (using model kimi 2.6)

I manually checked the code. It seems legit and should not rise any new issues. Nevertheless I am running this version of Cosmos Cloud on my nodes to catch potential issues asap.

~~There is one line I'm not sure we should leave in the code or not: https://github.com/azukaar/Cosmos-Server/blob/be4c720087a684811d179e0b0350572bb93c4806/client/src/pages/servapps/containers/volumes.jsx#L114~~

Update: this gets addressed here: https://github.com/azukaar/Cosmos-Server/pull/599

## Summary

Fixes the inconsistency where **Volume Target and Source** were the only fields using **uppercase** (`Type`, `Source`, `Target`) while every other runtime variable in Cosmos uses **lowercase** (`type`, `source`, `target`).

## Problem

- **Market templates** and **Docker Compose imports** use lowercase field names (`source`, `target`, `type`) — this is the Docker Compose spec convention.
- **Runtime container operations** (create, update, export) used the raw Docker SDK `mount.Mount` struct, which serializes with **uppercase** Go exported fields (`Source`, `Target`, `Type`).
- This caused the frontend to juggle two casing conventions depending on whether a volume came from a template, a compose file, or an inspected running container.

## Solution

Introduced a Cosmos-local `CosmosMount` type with lowercase JSON tags and bidirectional conversion helpers:

| Before | After |
|--------|-------|
| `[]mount.Mount` (`{"Type":"bind","Source":"/x","Target":"/y"}`) | `[]CosmosMount` (`{"type":"bind","source":"/x","target":"/y"}`) |

### Key changes

- **New type:** `src/docker/mount.go` — `CosmosMount` with lowercase tags and helper methods:
  - `ToDockerMount()` / `ToDockerMountSlice()` — send to Docker SDK
  - `FromDockerMount()` / `FromDockerMountSlice()` — receive from Docker SDK
  - `UnmarshalJSON()` — **accepts both lowercase and uppercase on input**
- **Backend structs updated:**
  - `ContainerCreateRequestContainer.Volumes` → `[]CosmosMount`
  - `ContainerForm.Volumes` → `[]CosmosMount` (JSON tag changed from `Volumes` → `volumes`)
- **Conversion points:** `CreateService()`, `UpdateContainerRoute()`, `ExportContainer()` now convert at the Docker SDK boundary.
- **Frontend updated:** `volumes.jsx`, `docker-compose.jsx`, `newServiceForm.jsx` use lowercase fields exclusively.

## Backward Compatibility

The custom `UnmarshalJSON` on `CosmosMount` accepts **both** casing styles on input:

```json
// Lowercase (new canonical) — ✅ works
{"type":"bind","source":"/host","target":"/cont"}

// Uppercase (legacy Docker SDK) — ✅ still works
{"Type":"volume","Source":"myvol","Target":"/data"}
```

**Serialization always outputs lowercase**, so clients and generated SDKs will gradually migrate without breaking.

## Testing

- [x] `go build ./src/docker/...` and `go build ./src/...` pass
- [x] Verified lowercase input → correct parsing
- [x] Verified uppercase input → correct parsing (backward compat)
- [x] Verified serialization → always lowercase

---

### Checklist

- [x] Branch targets `unstable`
- [x] Go code builds cleanly
- [x] Backward compatibility preserved for API consumers
- [x] Frontend volume flows updated (import, create, update, export)