### PR TITLE
Fix Bitwarden Android autofill: use valid input type for nickname field

### DIFF
--- a/client/src/pages/authentication/auth-forms/AuthLogin.jsx
+++ b/client/src/pages/authentication/auth-forms/AuthLogin.jsx
@@ -128,7 +128,7 @@ const AuthLogin = () => {
                                     <InputLabel htmlFor="nickname-login">{t('global.nicknameLabel')}</InputLabel>
                                     <OutlinedInput
                                         id="nickname-login"
-                                        type="nickname"
+                                        type="text"
                                         value={values.nickname}
                                         name="nickname"
                                         autoComplete="username"
@@ -155,6 +155,7 @@ const AuthLogin = () => {
                                         type={showPassword ? 'text' : 'password'}
                                         value={values.password}
                                         name="password"
+                                        autoComplete="current-password"
                                         onBlur={handleBlur}
                                         onChange={handleChange}
                                         endAdornment={

--- a/client/src/pages/authentication/auth-forms/AuthRegister.jsx
+++ b/client/src/pages/authentication/auth-forms/AuthRegister.jsx
@@ -109,7 +109,7 @@ const AuthRegister = ({nickname, isRegister, isInviteLink, regkey}) => {
                                     <InputLabel htmlFor="nickname-signup">{t('global.nicknameLabel')}</InputLabel>
                                     <OutlinedInput
                                         id="nickname-login"
-                                        type="nickname"
+                                        type="text"
                                         value={nickname}
                                         name="nickname"
                                         onBlur={handleBlur}


### PR DESCRIPTION
Android bitwarden client did not recognize the nickname field hence not offering to autofill and not autofilling when selecting a login from dropbown via password field. Only the password field gets autofilled.

## Disclaimer
Written with help of Plurality ( deepseek-v4-flash-0731 )

## Summary
The nickname fields on the login and registration forms were rendered with an invalid HTML input type (`type="nickname"`). This breaks field classification on Android's Autofill Framework, so Bitwarden on Android could not reliably map a saved username to the nickname field (and often wouldn't offer to autofill at all).

## Problem details
- **Invalid input type**: `"nickname"` is not a valid HTML input `type`. Desktop browsers silently coerce it to `text`, which is why desktop password managers mostly work — but Android's Autofill Framework relies on accurate type + autocomplete hints to classify fields. An invalid type weakens that classification and Android refuses the fill.
- **Missing `current-password` hint:** the password field on the login form had no `autocomplete="current-password"` hint. The iOS/Android autofill framework needs *both* halves of a recognized pair (`username` + `current-password`) before it will offer to fill a login form.

## Fixes
- Changed `type="nickname"` → `type="text"` in:
  - `client/src/pages/authentication/auth-forms/AuthLogin.jsx`
  - `client/src/pages/authentication/auth-forms/AuthRegister.jsx`
- Added `autoComplete="current-password"` to the login password field so Android recognizes the nickname/password pair as a login form.

## Notes
- No behavioral change to validation or logic — the `name="nickname"` attribute and form state handling are untouched.
- Client-side only; no backend or API changes.

---

Want me to tweak the tone, add a screenshot/visual, or include your testing steps? Also, if you'd like, I can open the PR for you via the API using the PAT — just say the word.