### PR TITLE
fix(http): restore HTTP to HTTPS redirect handler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
  - Allow client servers in Constellation
 
 ## Version 0.23.00
+ - Fix HTTP to HTTPS redirect returning 404 when HTTPS is enabled
  - Remove Lungo, use SQLite instead
  - Remove MongoDB use SQLite / Postgres instead 
  - Remove date based sync - use opLog based sync

--- a/src/httpServer.go
+++ b/src/httpServer.go
@@ -121,7 +121,7 @@ func startHTTPSServer(router *mux.Router) error {
 	go (func () {
 		httpRouter := mux.NewRouter()
 		httpRouter.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if utils.GetMainConfig().HTTPConfig.AllowHTTPLocalIPAccess && utils.IsLocalIP(r.RemoteAddr) {
+			if (utils.GetMainConfig().HTTPConfig.AllowHTTPLocalIPAccess && utils.IsLocalIP(r.RemoteAddr)) || constellation.IsConstellationIP(r.RemoteAddr) {
 				router.ServeHTTP(w, r)
 			} else {
 				// change port in host

--- a/src/httpServer.go
+++ b/src/httpServer.go
@@ -120,6 +120,22 @@ func startHTTPSServer(router *mux.Router) error {
 	// redirect http to https
 	go (func () {
 		httpRouter := mux.NewRouter()
+		httpRouter.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if utils.GetMainConfig().HTTPConfig.AllowHTTPLocalIPAccess && utils.IsLocalIP(r.RemoteAddr) {
+				router.ServeHTTP(w, r)
+			} else {
+				// change port in host
+				if strings.HasSuffix(r.Host, ":"+serverPortHTTP) {
+					if serverPortHTTPS != "443" {
+						r.Host = r.Host[:len(r.Host)-len(":"+serverPortHTTP)] + ":" + serverPortHTTPS
+					} else {
+						r.Host = r.Host[:len(r.Host)-len(":"+serverPortHTTP)]
+					}
+				}
+
+				http.Redirect(w, r, "https://"+r.Host+r.URL.String(), http.StatusMovedPermanently)
+			}
+		})
 
 		HTTPServer2 = &http.Server{
 			Addr: "0.0.0.0:" + serverPortHTTP,

--- a/src/httpServer.go
+++ b/src/httpServer.go
@@ -121,7 +121,9 @@ func startHTTPSServer(router *mux.Router) error {
 	go (func () {
 		httpRouter := mux.NewRouter()
 		httpRouter.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if (utils.GetMainConfig().HTTPConfig.AllowHTTPLocalIPAccess && utils.IsLocalIP(r.RemoteAddr)) || constellation.IsConstellationIP(r.RemoteAddr) {
+			remoteIP, _ := utils.SplitIP(r.RemoteAddr)
+
+			if (utils.GetMainConfig().HTTPConfig.AllowHTTPLocalIPAccess && utils.IsLocalIP(remoteIP)) || constellation.IsConstellationIP(remoteIP) {
 				router.ServeHTTP(w, r)
 			} else {
 				// change port in host


### PR DESCRIPTION
## Why this PR is necessary

When **HTTPS is enabled**, plain-HTTP requests on port 80 return a **404** instead of being redirected to HTTPS. Any client that still connects over HTTP (a bookmark, an app hard-coded to port 80, a health check, or a device on the local network) just gets "not found".

### Root cause

In `src/httpServer.go`, `startHTTPSServer()` starts a separate HTTP listener to redirect HTTP → HTTPS, but the catch-all handler that did the redirecting was accidentally removed, leaving that listener's router empty. With an empty Gorilla/mux router, every request falls through to the default `NotFoundHandler`, which returns a **404** for all paths.

### Where the bug was introduced

The catch-all redirect handler was accidentally **removed in commit `748302d`** — *"[skip ci] Constellation work"*. Before that commit, the handler redirected HTTP → HTTPS (and served local-IP / Constellation internal traffic directly over HTTP). That commit deleted the entire `httpRouter.PathPrefix("/").HandlerFunc(...)` block, leaving the router empty.

## The fix

Restores the catch-all handler so that when HTTPS is configured:

- Requests from a known **Constellation / VPN peer IP** are served **directly over HTTP** (the tunnel is already encrypted by the Nebula VPN and can't use HTTPS from a bare private IP) — via `constellation.IsConstellationIP`, replacing the old hardcoded `192.168.201.1` check.
- Requests from a **local IP** with `AllowHTTPLocalIPAccess` enabled are served directly over HTTP.
- All other plain-HTTP requests are **redirected to HTTPS with a 301**, rewriting the port to the configured HTTPS port.

### Compatibility: Constellation URL Tunneling

URL tunneling still works. Tunneled requests arrive at the recipient's HTTP listener from a known VPN peer IP, which `constellation.IsConstellationIP` recognizes, so they bypass the redirect and are served over the tunnel directly — **regardless of the `AllowHTTPLocalIPAccess` setting**. Only genuinely external HTTP traffic is redirected to HTTPS.

A `changelog.md` entry was added under `Version 0.23.00`.

## Commits

- `32ecd4b` — restore the HTTP→HTTPS redirect handler (the core 404 fix).
- `19a0dc0` — preserve Constellation URL tunneling in the redirect (tunnel bypass).