### PR TITLE
feat(docker): end-to-end depends_on with docker-compose parity, restart cascade, and service/container-name resolution

### DIFF
--- a/client/src/pages/servapps/servapps.jsx
+++ b/client/src/pages/servapps/servapps.jsx
@@ -144,10 +144,10 @@ const ServApps = ({stack}) => {
   ]
 
   const servAppsStacked = servApps && servApps.reduce((acc, app) => {
-    // if has label cosmos.stack, add to stack
-    if(!stack && (app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'])) {
-      let stackName = app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'];
-      let stackMain = app.Labels['cosmos.stack.main'] || (app.Labels['com.docker.compose.container-number'] == '1' && app.Names[0].replace('/', ''));
+    // if has label cosmos-stack, add to stack
+    if(!stack && (app.Labels['cosmos-stack'] || app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'])) {
+      let stackName = app.Labels['cosmos-stack'] || app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'];
+      let stackMain = app.Labels['cosmos-stack-main'] ||  app.Labels['cosmos.stack.main'] || (app.Labels['com.docker.compose.container-number'] == '1' && app.Names[0].replace('/', ''));
       
       if(!acc[stackName]) {
         acc[stackName] = {
@@ -199,7 +199,7 @@ const ServApps = ({stack}) => {
       if(stackMain == app.Names[0].replace('/', '') || !acc[stackName].app) {
         acc[stackName].app = app;
       }
-    } else if (!stack || (stack && (app.Labels['cosmos.stack'] === stack || app.Labels['com.docker.compose.project'] === stack))){
+    } else if (!stack || (stack && (app.Labels['cosmos-stack'] === stack || app.Labels['cosmos.stack'] === stack || app.Labels['com.docker.compose.project'] === stack))){
       // else add to default stack
       acc[app.Names[0]] = {
         type: 'app',

--- a/client/src/pages/servapps/servapps.jsx
+++ b/client/src/pages/servapps/servapps.jsx
@@ -144,10 +144,10 @@ const ServApps = ({stack}) => {
   ]
 
   const servAppsStacked = servApps && servApps.reduce((acc, app) => {
-    // if has label cosmos-stack, add to stack
-    if(!stack && (app.Labels['cosmos-stack'] || app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'])) {
-      let stackName = app.Labels['cosmos-stack'] || app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'];
-      let stackMain = app.Labels['cosmos-stack-main'] ||  app.Labels['cosmos.stack.main'] || (app.Labels['com.docker.compose.container-number'] == '1' && app.Names[0].replace('/', ''));
+    // if has label cosmos.stack, add to stack
+    if(!stack && (app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'])) {
+      let stackName = app.Labels['cosmos.stack'] || app.Labels['com.docker.compose.project'];
+      let stackMain = app.Labels['cosmos.stack.main'] || (app.Labels['com.docker.compose.container-number'] == '1' && app.Names[0].replace('/', ''));
       
       if(!acc[stackName]) {
         acc[stackName] = {
@@ -199,7 +199,7 @@ const ServApps = ({stack}) => {
       if(stackMain == app.Names[0].replace('/', '') || !acc[stackName].app) {
         acc[stackName].app = app;
       }
-    } else if (!stack || (stack && (app.Labels['cosmos-stack'] === stack || app.Labels['cosmos.stack'] === stack || app.Labels['com.docker.compose.project'] === stack))){
+    } else if (!stack || (stack && (app.Labels['cosmos.stack'] === stack || app.Labels['com.docker.compose.project'] === stack))){
       // else add to default stack
       acc[app.Names[0]] = {
         type: 'app',

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -526,6 +526,30 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			OpenStdin:    container.StdinOpen,
 		}
 
+		// Tag multi-service compose stacks with the stack labels so the UI
+		// groups them (servapps.jsx reads cosmos-stack / cosmos.stack /
+		// com.docker.compose.project) and so the restart/recreate dependents
+		// cascade can scope itself to the same stack. The frontend also writes
+		// these, but doing it server-side makes creation deterministic. A
+		// single-service compose is NOT a stack and stays untagged.
+		if len(serviceRequest.Services) > 1 {
+			if containerConfig.Labels == nil {
+				containerConfig.Labels = make(map[string]string)
+			}
+			if containerConfig.Labels["cosmos-stack"] == "" && containerConfig.Labels["cosmos.stack"] == "" && containerConfig.Labels["com.docker.compose.project"] == "" {
+				containerConfig.Labels["cosmos.stack"] = serviceName
+			}
+			// mark the first service as the stack main
+			first := ""
+			for k := range serviceRequest.Services {
+				first = k
+				break
+			}
+			if containerConfig.Labels["cosmos-stack-main"] == "" && containerConfig.Labels["cosmos.stack.main"] == "" && serviceName == first {
+				containerConfig.Labels["cosmos.stack.main"] = "true"
+			}
+		}
+
 		// Persist the depends_on graph on the container in docker-compose's own
 		// format (com.docker.compose.depends_on label) so runtime paths
 		// (restart / recreate / update) honor it even though they bypass

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -526,17 +526,22 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			OpenStdin:    container.StdinOpen,
 		}
 
-		// Persist the depends_on graph on the container so runtime paths
-		// (restart / recreate / update) can honor it even though they bypass
-		// CreateService's pre-start ordering.
+		// Persist the depends_on graph on the container in docker-compose's own
+		// format (com.docker.compose.depends_on label) so runtime paths
+		// (restart / recreate / update) honor it even though they bypass
+		// CreateService's pre-start ordering, and so compose-imported stacks
+		// keep working.
 		if len(container.DependsOn) > 0 {
-			deps := make(map[string]string, len(container.DependsOn))
+			deps := make(map[string]dependsOnEntry, len(container.DependsOn))
 			for depName, depCfg := range container.DependsOn {
 				cond := depCfg.Condition
 				if cond == "" {
 					cond = DepConditionStarted
 				}
-				deps[depName] = cond
+				deps[depName] = dependsOnEntry{
+					Condition: cond,
+					Restart:   depCfg.Restart == "true" || depCfg.Restart == "always",
+				}
 			}
 			SetDependsOnLabels(containerConfig, deps)
 		}
@@ -1164,6 +1169,52 @@ func ReOrderServices(serviceMap map[string]ContainerCreateRequestContainer) ([]C
 	startOrder := []ContainerCreateRequestContainer{}
 	mustStart := false
 
+	// Build a map of service key -> container name so dependencies (which
+	// reference services by their compose key, per docker-compose) can be
+	// matched against the containers in startOrder (which are keyed by
+	// container name). docker-compose's dependency graph is built entirely
+	// from the `depends_on` field. network_mode / ipc / pid / volumes_from
+	// references are NOT graph edges in compose: "service:" aliases are
+	// resolved to container:<id> at create time and Docker enforces the
+	// referenced container exists first. We keep a *soft* ordering constraint
+	// for network_mode targets that are part of this same batch (the target
+	// must be created and started first), but an external target (e.g. a
+	// tailscale sidecar already running) is never a hard dependency error.
+	nameByService := map[string]string{}
+	for key, svc := range serviceMap {
+		// container.Name defaults to the service key when container_name is
+		// unset (see CreateService), so this mapping is usually identity.
+		nameByService[key] = svc.Name
+	}
+
+	// Invert: also allow matching by container name directly (defensive).
+	serviceByName := map[string]string{}
+	for key, svc := range serviceMap {
+		serviceByName[svc.Name] = key
+	}
+
+	// Resolve a dependency reference to a container name. Dependencies are
+	// declared by service key (compose semantics); fall back to matching the
+	// container name directly for robustness.
+	resolveDep := func(dep string) string {
+		if name, ok := nameByService[dep]; ok && name != "" {
+			return name
+		}
+		return dep
+	}
+
+	// inBatch reports whether a service/container name is part of this compose
+	// creation batch (by service key OR by container name).
+	inBatch := func(name string) bool {
+		if _, ok := serviceMap[name]; ok {
+			return true
+		}
+		if _, ok := serviceByName[name]; ok {
+			return true
+		}
+		return false
+	}
+
 	for len(serviceMap) > 0 {
 		// Keep track of whether we've added any services in this iteration
 		changed := false
@@ -1173,12 +1224,20 @@ func ReOrderServices(serviceMap map[string]ContainerCreateRequestContainer) ([]C
 			if dependencies == nil {
 				dependencies = make(map[string]ContainerCreateRequestContainerDependsOnCont)
 			}
-			
-			// if network_mode is container: then we need to add a dependency
-			if strings.HasPrefix(string(service.NetworkMode), "container:") {
-				depService := strings.TrimPrefix(string(service.NetworkMode), "container:")
-				dependencies[depService] = ContainerCreateRequestContainerDependsOnCont{
-					Condition: "service_started",
+
+			// Soft ordering constraint: if network_mode references another
+			// service that is part of this batch, that service must start
+			// first. Unlike depends_on this never hard-fails for an external
+			// target: if the referenced container is not in the batch, Docker
+			// enforces it exists at create time (compose parity).
+			if nm := string(service.NetworkMode); strings.HasPrefix(nm, "container:") || strings.HasPrefix(nm, "service:") {
+				target := strings.TrimPrefix(strings.TrimPrefix(nm, "container:"), "service:")
+				if target != "" && inBatch(target) {
+					if _, ok := dependencies[target]; !ok {
+						dependencies[target] = ContainerCreateRequestContainerDependsOnCont{
+							Condition: "service_started",
+						}
+					}
 				}
 			}
 
@@ -1186,9 +1245,10 @@ func ReOrderServices(serviceMap map[string]ContainerCreateRequestContainer) ([]C
 			// Check if all dependencies are already in startOrder
 			allDependenciesStarted := true
 			for dependency, dependencyDetails := range dependencies {
+				depName := resolveDep(dependency)
 				dependencyStarted := false
 				for _, startedService := range startOrder {
-					if startedService.Name == dependency {
+					if startedService.Name == depName {
 						dependencyStarted = true
 
 						if dependencyDetails.Condition == "service_healthy" || dependencyDetails.Condition == "service_started" {
@@ -1196,6 +1256,14 @@ func ReOrderServices(serviceMap map[string]ContainerCreateRequestContainer) ([]C
 						}
 
 						break
+					}
+				}
+				// A dependency on a service not in this compose batch (e.g. an
+				// external/named container): the target must already exist; we
+				// treat it as satisfied (Docker will fail create if it doesn't).
+				if !dependencyStarted {
+					if !inBatch(dependency) {
+						dependencyStarted = true
 					}
 				}
 				if !dependencyStarted {
@@ -1226,15 +1294,8 @@ func ReOrderServices(serviceMap map[string]ContainerCreateRequestContainer) ([]C
 			errorMessage += "Could not start service: " + name + "\n"
 			errorMessage += "Unsatisfied dependencies:\n"
 
-			// if network_mode is container: then we need to add a dependency
-			if strings.HasPrefix(string(serviceMap[name].NetworkMode), "container:") {
-				depService := strings.TrimPrefix(string(serviceMap[name].NetworkMode), "container:")
-				errorMessage += depService + " (network_mode)\n"
-			}
-
 			for dependency, _ := range serviceMap[name].DependsOn {
-				_, ok := serviceMap[dependency]
-				if ok {
+				if inBatch(dependency) {
 					errorMessage += dependency + "\n"
 				}
 			}

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -526,6 +526,21 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			OpenStdin:    container.StdinOpen,
 		}
 
+		// Persist the depends_on graph on the container so runtime paths
+		// (restart / recreate / update) can honor it even though they bypass
+		// CreateService's pre-start ordering.
+		if len(container.DependsOn) > 0 {
+			deps := make(map[string]string, len(container.DependsOn))
+			for depName, depCfg := range container.DependsOn {
+				cond := depCfg.Condition
+				if cond == "" {
+					cond = DepConditionStarted
+				}
+				deps[depName] = cond
+			}
+			SetDependsOnLabels(containerConfig, deps)
+		}
+
 		// check if there's an empty TZ env, if so, replace it with the host's TZ
 		if containerConfig.Env != nil {
 			for i, env := range containerConfig.Env {
@@ -1009,8 +1024,30 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 		return err
 	}
 
-	// Start all the newly created containers
+	// Start all the newly created containers.
+	//
+	// ReOrderServices guarantees dependencies are created first (and their
+	// start attempt happens before this loop reaches the dependent). For
+	// service_healthy / service_completed_successfully conditions we also need
+	// to *wait* for the condition to be met before starting the dependent.
 	for _, container := range startOrder {
+		if len(container.DependsOn) > 0 {
+			for depName, depCfg := range container.DependsOn {
+				cond := depCfg.Condition
+				if cond == "" {
+					cond = DepConditionStarted
+				}
+				utils.Log(fmt.Sprintf("Waiting for dependency %s (%s) before starting %s", depName, cond, container.Name))
+				OnLog(fmt.Sprintf("Waiting for dependency %s (%s) before starting %s\n", depName, cond, container.Name))
+				if err := WaitForDepCondition(DockerContext, depName, cond); err != nil {
+					utils.Error("CreateService: Start Container", err)
+					OnLog(utils.DoErr("Rolling back changes because of -- dependency wait error: "+err.Error()))
+					Rollback(rollbackActions, OnLog)
+					return err
+				}
+			}
+		}
+
 		err = DockerClient.ContainerStart(DockerContext, container.Name, conttype.StartOptions{})
 		if err != nil {
 			utils.Error("CreateService: Start Container", err)

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -527,16 +527,16 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 		}
 
 		// Tag multi-service compose stacks with the stack labels so the UI
-		// groups them (servapps.jsx reads cosmos-stack / cosmos.stack /
-		// com.docker.compose.project) and so the restart/recreate dependents
-		// cascade can scope itself to the same stack. The frontend also writes
-		// these, but doing it server-side makes creation deterministic. A
-		// single-service compose is NOT a stack and stays untagged.
+		// groups them (servapps.jsx reads cosmos.stack / com.docker.compose.project)
+		// and so the restart/recreate dependents cascade can scope itself to the
+		// same stack. The frontend also writes these, but doing it server-side
+		// makes creation deterministic. A single-service compose is NOT a stack
+		// and stays untagged.
 		if len(serviceRequest.Services) > 1 {
 			if containerConfig.Labels == nil {
 				containerConfig.Labels = make(map[string]string)
 			}
-			if containerConfig.Labels["cosmos-stack"] == "" && containerConfig.Labels["cosmos.stack"] == "" && containerConfig.Labels["com.docker.compose.project"] == "" {
+			if containerConfig.Labels["cosmos.stack"] == "" && containerConfig.Labels["com.docker.compose.project"] == "" {
 				containerConfig.Labels["cosmos.stack"] = serviceName
 			}
 			// mark the first service as the stack main
@@ -545,7 +545,7 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 				first = k
 				break
 			}
-			if containerConfig.Labels["cosmos-stack-main"] == "" && containerConfig.Labels["cosmos.stack.main"] == "" && serviceName == first {
+			if containerConfig.Labels["cosmos.stack.main"] == "" && serviceName == first {
 				containerConfig.Labels["cosmos.stack.main"] = "true"
 			}
 		}

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -759,14 +759,22 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			},
 		}
 
-		// cosmos-force-network-mode logic
+		// cosmos-force-network-mode logic: normalize container/service refs to
+		// stable container:<name> so the reference survives recreations of the
+		// referenced container (an ID would go stale; service: is a compose
+		// alias that Docker itself resolves to container:<id> at create time).
 		if containerConfig.Labels["cosmos-force-network-mode"] == "" {
-			if (strings.HasPrefix(string(hostConfig.NetworkMode), "service:") ||
-				strings.HasPrefix(string(hostConfig.NetworkMode), "container:")) {
-					containerConfig.Labels["cosmos-force-network-mode"] = string(hostConfig.NetworkMode)
+			if NetworkModeContainerRef(string(hostConfig.NetworkMode)) || NetworkModeServiceRef(string(hostConfig.NetworkMode)) {
+				normalized := ContainerRefToName(string(hostConfig.NetworkMode))
+				containerConfig.Labels["cosmos-force-network-mode"] = normalized
+				if normalized != string(hostConfig.NetworkMode) {
+					hostConfig.NetworkMode = conttype.NetworkMode(normalized)
+				}
 			}
 		} else {
-			hostConfig.NetworkMode = conttype.NetworkMode(containerConfig.Labels["cosmos-force-network-mode"])
+			normalized := ContainerRefToName(containerConfig.Labels["cosmos-force-network-mode"])
+			hostConfig.NetworkMode = conttype.NetworkMode(normalized)
+			containerConfig.Labels["cosmos-force-network-mode"] = normalized
 			utils.Debug("Forcing network mode to " + string(hostConfig.NetworkMode))
 		}
 

--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -526,12 +526,9 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			OpenStdin:    container.StdinOpen,
 		}
 
-		// Tag multi-service compose stacks with the stack labels so the UI
-		// groups them (servapps.jsx reads cosmos.stack / com.docker.compose.project)
-		// and so the restart/recreate dependents cascade can scope itself to the
-		// same stack. The frontend also writes these, but doing it server-side
-		// makes creation deterministic. A single-service compose is NOT a stack
-		// and stays untagged.
+		// Tag multi-service compose stacks with cosmos.stack (+ .main) so the
+		// UI groups them and the dependents cascade can scope by stack. Single
+		// services stay untagged.
 		if len(serviceRequest.Services) > 1 {
 			if containerConfig.Labels == nil {
 				containerConfig.Labels = make(map[string]string)
@@ -550,11 +547,8 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			}
 		}
 
-		// Persist the depends_on graph on the container in docker-compose's own
-		// format (com.docker.compose.depends_on label) so runtime paths
-		// (restart / recreate / update) honor it even though they bypass
-		// CreateService's pre-start ordering, and so compose-imported stacks
-		// keep working.
+		// Persist depends_on in compose's com.docker.compose.depends_on label
+		// so runtime restart/recreate paths and compose-imported stacks work.
 		if len(container.DependsOn) > 0 {
 			deps := make(map[string]dependsOnEntry, len(container.DependsOn))
 			for depName, depCfg := range container.DependsOn {
@@ -803,10 +797,7 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			},
 		}
 
-		// cosmos-force-network-mode logic: normalize container/service refs to
-		// stable container:<name> so the reference survives recreations of the
-		// referenced container (an ID would go stale; service: is a compose
-		// alias that Docker itself resolves to container:<id> at create time).
+		// normalize container/service refs to stable container:<name>
 		if containerConfig.Labels["cosmos-force-network-mode"] == "" {
 			if NetworkModeContainerRef(string(hostConfig.NetworkMode)) || NetworkModeServiceRef(string(hostConfig.NetworkMode)) {
 				normalized := ContainerRefToName(string(hostConfig.NetworkMode))
@@ -1053,12 +1044,8 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 		return err
 	}
 
-	// Start all the newly created containers.
-	//
-	// ReOrderServices guarantees dependencies are created first (and their
-	// start attempt happens before this loop reaches the dependent). For
-	// service_healthy / service_completed_successfully conditions we also need
-	// to *wait* for the condition to be met before starting the dependent.
+	// Start containers in dependency order, waiting for non-started
+	// conditions (service_healthy / service_completed_successfully).
 	for _, container := range startOrder {
 		if len(container.DependsOn) > 0 {
 			for depName, depCfg := range container.DependsOn {
@@ -1193,17 +1180,10 @@ func ReOrderServices(serviceMap map[string]ContainerCreateRequestContainer) ([]C
 	startOrder := []ContainerCreateRequestContainer{}
 	mustStart := false
 
-	// Build a map of service key -> container name so dependencies (which
-	// reference services by their compose key, per docker-compose) can be
-	// matched against the containers in startOrder (which are keyed by
-	// container name). docker-compose's dependency graph is built entirely
-	// from the `depends_on` field. network_mode / ipc / pid / volumes_from
-	// references are NOT graph edges in compose: "service:" aliases are
-	// resolved to container:<id> at create time and Docker enforces the
-	// referenced container exists first. We keep a *soft* ordering constraint
-	// for network_mode targets that are part of this same batch (the target
-	// must be created and started first), but an external target (e.g. a
-	// tailscale sidecar already running) is never a hard dependency error.
+	// depends_on keys are compose service names; startOrder is keyed by
+	// container name. network_mode is NOT a depends_on edge in compose: it is
+	// resolved at create and Docker enforces the target exists, so we only add
+	// a soft in-batch ordering constraint (external targets never hard-error).
 	nameByService := map[string]string{}
 	for key, svc := range serviceMap {
 		// container.Name defaults to the service key when container_name is
@@ -1211,7 +1191,7 @@ func ReOrderServices(serviceMap map[string]ContainerCreateRequestContainer) ([]C
 		nameByService[key] = svc.Name
 	}
 
-	// Invert: also allow matching by container name directly (defensive).
+	// also allow matching by container name
 	serviceByName := map[string]string{}
 	for key, svc := range serviceMap {
 		serviceByName[svc.Name] = key

--- a/src/docker/api_getcontainers.go
+++ b/src/docker/api_getcontainers.go
@@ -61,9 +61,7 @@ func GetContainerRoute(w http.ResponseWriter, req *http.Request) {
 			container.Config.Env = masked
 		}
 
-		// Normalize container-mode references to stable container:<name> so the
-		// UI never round-trips a container ID that goes stale when the
-		// referenced container is recreated.
+		// normalize container refs to stable container:<name> for the UI
 		if container.HostConfig != nil {
 			container.HostConfig.NetworkMode = conttype.NetworkMode(ContainerRefToName(string(container.HostConfig.NetworkMode)))
 		}

--- a/src/docker/api_getcontainers.go
+++ b/src/docker/api_getcontainers.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/azukaar/cosmos-server/src/utils"
+
+	conttype "github.com/docker/docker/api/types/container"
 )
 
 // GetContainerRoute godoc
@@ -57,6 +59,13 @@ func GetContainerRoute(w http.ResponseWriter, req *http.Request) {
 				}
 			}
 			container.Config.Env = masked
+		}
+
+		// Normalize container-mode references to stable container:<name> so the
+		// UI never round-trips a container ID that goes stale when the
+		// referenced container is recreated.
+		if container.HostConfig != nil {
+			container.HostConfig.NetworkMode = conttype.NetworkMode(ContainerRefToName(string(container.HostConfig.NetworkMode)))
 		}
 
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/src/docker/api_managecont.go
+++ b/src/docker/api_managecont.go
@@ -68,7 +68,7 @@ func ManageContainerRoute(w http.ResponseWriter, req *http.Request) {
 		case "stop":
 			err = DockerClient.ContainerStop(DockerContext, container.ID, contstuff.StopOptions{})
 		case "start":
-			// honor depends_on at runtime: wait for dependencies before starting
+			// wait for dependencies before starting
 			if errW := WaitForDependsOn(DockerContext, container.ID); errW != nil {
 				utils.Error("ManageContainer: depends_on wait failed before start", errW)
 				utils.HTTPError(w, "Cannot start container: "+errW.Error(), http.StatusInternalServerError, "DS004")
@@ -76,7 +76,7 @@ func ManageContainerRoute(w http.ResponseWriter, req *http.Request) {
 			}
 			err = DockerClient.ContainerStart(DockerContext, container.ID, contstuff.StartOptions{})
 		case "restart":
-			// honor depends_on at runtime: wait for dependencies before restarting
+			// wait for dependencies before restarting
 			if errW := WaitForDependsOn(DockerContext, container.ID); errW != nil {
 				utils.Error("ManageContainer: depends_on wait failed before restart", errW)
 				utils.HTTPError(w, "Cannot restart container: "+errW.Error(), http.StatusInternalServerError, "DS004")
@@ -84,9 +84,7 @@ func ManageContainerRoute(w http.ResponseWriter, req *http.Request) {
 			}
 			err = DockerClient.ContainerRestart(DockerContext, container.ID, contstuff.StopOptions{})
 			if err == nil {
-				// Same-stack dependents must come back with their dependency:
-				// network_mode/ipc/pid namespace sharers (always) and
-				// depends_on restart:true dependents (docker-compose parity).
+				// same-stack dependents (network_mode, depends_on restart:true)
 				restarted := RestartStackDependents(container.ID)
 				if len(restarted) > 0 {
 					utils.Log(fmt.Sprintf("ManageContainer: restarted %d stack dependents of %s: %v", len(restarted), containerName, restarted))

--- a/src/docker/api_managecont.go
+++ b/src/docker/api_managecont.go
@@ -83,6 +83,15 @@ func ManageContainerRoute(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 			err = DockerClient.ContainerRestart(DockerContext, container.ID, contstuff.StopOptions{})
+			if err == nil {
+				// Same-stack dependents must come back with their dependency:
+				// network_mode/ipc/pid namespace sharers (always) and
+				// depends_on restart:true dependents (docker-compose parity).
+				restarted := RestartStackDependents(container.ID)
+				if len(restarted) > 0 {
+					utils.Log(fmt.Sprintf("ManageContainer: restarted %d stack dependents of %s: %v", len(restarted), containerName, restarted))
+				}
+			}
 		case "kill":
 			err = DockerClient.ContainerKill(DockerContext, container.ID, "")
 		case "remove":

--- a/src/docker/api_managecont.go
+++ b/src/docker/api_managecont.go
@@ -68,8 +68,20 @@ func ManageContainerRoute(w http.ResponseWriter, req *http.Request) {
 		case "stop":
 			err = DockerClient.ContainerStop(DockerContext, container.ID, contstuff.StopOptions{})
 		case "start":
+			// honor depends_on at runtime: wait for dependencies before starting
+			if errW := WaitForDependsOn(DockerContext, container.ID); errW != nil {
+				utils.Error("ManageContainer: depends_on wait failed before start", errW)
+				utils.HTTPError(w, "Cannot start container: "+errW.Error(), http.StatusInternalServerError, "DS004")
+				return
+			}
 			err = DockerClient.ContainerStart(DockerContext, container.ID, contstuff.StartOptions{})
 		case "restart":
+			// honor depends_on at runtime: wait for dependencies before restarting
+			if errW := WaitForDependsOn(DockerContext, container.ID); errW != nil {
+				utils.Error("ManageContainer: depends_on wait failed before restart", errW)
+				utils.HTTPError(w, "Cannot restart container: "+errW.Error(), http.StatusInternalServerError, "DS004")
+				return
+			}
 			err = DockerClient.ContainerRestart(DockerContext, container.ID, contstuff.StopOptions{})
 		case "kill":
 			err = DockerClient.ContainerKill(DockerContext, container.ID, "")

--- a/src/docker/api_updateContainer.go
+++ b/src/docker/api_updateContainer.go
@@ -135,11 +135,7 @@ func UpdateContainerRoute(w http.ResponseWriter, req *http.Request) {
 			container.Config.OpenStdin = form.Interactive == 2
 		}
 		if(form.NetworkMode != "") {
-			// Normalize container/service refs to stable container:<name> so the
-			// reference survives recreations of the referenced container. The
-			// UI may send a container ID (e.g. when the container picker was
-			// filled from an inspect that got a container:<id> from Docker);
-			// storing an ID would break on the next recreate of that container.
+			// normalize container/service refs to stable container:<name>
 			networkMode := ContainerRefToName(form.NetworkMode)
 			container.HostConfig.NetworkMode = containerType.NetworkMode(networkMode)
 			// if not bridge, remove mac address

--- a/src/docker/api_updateContainer.go
+++ b/src/docker/api_updateContainer.go
@@ -135,17 +135,23 @@ func UpdateContainerRoute(w http.ResponseWriter, req *http.Request) {
 			container.Config.OpenStdin = form.Interactive == 2
 		}
 		if(form.NetworkMode != "") {
-			container.HostConfig.NetworkMode = containerType.NetworkMode(form.NetworkMode)
+			// Normalize container/service refs to stable container:<name> so the
+			// reference survives recreations of the referenced container. The
+			// UI may send a container ID (e.g. when the container picker was
+			// filled from an inspect that got a container:<id> from Docker);
+			// storing an ID would break on the next recreate of that container.
+			networkMode := ContainerRefToName(form.NetworkMode)
+			container.HostConfig.NetworkMode = containerType.NetworkMode(networkMode)
 			// if not bridge, remove mac address
-			if form.NetworkMode != "bridge" &&
-				 form.NetworkMode != "default" {
+			if networkMode != "bridge" &&
+				 networkMode != "default" {
 					container.Config.MacAddress = ""
 			}
 			// update cosmos-force-network-mode label
 			if container.Config.Labels == nil {
 				container.Config.Labels = make(map[string]string)
 			}
-			container.Config.Labels["cosmos-force-network-mode"] = form.NetworkMode
+			container.Config.Labels["cosmos-force-network-mode"] = networkMode
 		}
 
 		// Resource constraints

--- a/src/docker/backups.go
+++ b/src/docker/backups.go
@@ -50,7 +50,7 @@ func getStackContainers(containerID string) ([]string, error) {
 	// Check for compose project name (stack name)
 	stackName := ""
 	for label, value := range container.Config.Labels {
-		if label == "com.docker.compose.project" || label == "cosmos.stack" {
+		if label == "com.docker.compose.project" || label == "cosmos-stack" || label == "cosmos.stack" {
 			stackName = value
 			break
 		}
@@ -75,7 +75,7 @@ func getStackContainers(containerID string) ([]string, error) {
 		}
 
 		for label, value := range fullContainer.Config.Labels {
-			if (label == "com.docker.compose.project" || label == "cosmos.stack") && value == stackName {
+			if (label == "com.docker.compose.project" || label == "cosmos-stack" || label == "cosmos.stack") && value == stackName {
 				stackContainers = append(stackContainers, cont.ID)
 				break
 			}

--- a/src/docker/backups.go
+++ b/src/docker/backups.go
@@ -50,7 +50,7 @@ func getStackContainers(containerID string) ([]string, error) {
 	// Check for compose project name (stack name)
 	stackName := ""
 	for label, value := range container.Config.Labels {
-		if label == "com.docker.compose.project" || label == "cosmos-stack" {
+		if label == "com.docker.compose.project" || label == "cosmos.stack" {
 			stackName = value
 			break
 		}
@@ -75,7 +75,7 @@ func getStackContainers(containerID string) ([]string, error) {
 		}
 
 		for label, value := range fullContainer.Config.Labels {
-			if (label == "com.docker.compose.project" || label == "cosmos-stack") && value == stackName {
+			if (label == "com.docker.compose.project" || label == "cosmos.stack") && value == stackName {
 				stackContainers = append(stackContainers, cont.ID)
 				break
 			}

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -308,7 +308,14 @@ func ReorderDependedOn(containerID string) {
 	}
 
 	// Find containers that (transitively) depend on the started one, or share
-	// its network namespace, and are currently stopped.
+	// its network namespace, and are currently stopped. Scoped to the same
+	// stack, and only depends_on entries with restart:true or network_mode
+	// references are honored (docker-compose parity).
+	startedStack := ""
+	if started.ContainerJSONBase != nil && started.Config != nil {
+		startedStack = ContainerStack(started.Config)
+	}
+
 	stoppedDependents := []string{}
 	seen := map[string]bool{}
 	var collect func(depName string)
@@ -318,11 +325,32 @@ func ReorderDependedOn(containerID string) {
 				continue
 			}
 			deps := DependsOnFromLabels(cInfo.full.Config)
-			_, hasDep := deps[depName]
-			sharesNetNS := strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "container:"+depName)
+			depEntry, hasDep := deps[depName]
+			sharesNetNS := strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "container:"+depName) ||
+				strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "service:"+depName)
 			if !hasDep && !sharesNetNS {
 				continue
 			}
+
+			if sharesNetNS {
+				// network-mode dependents are hard-bound to the target: always
+				// cascade, regardless of stack (scope like compose's project)
+				seen[cName] = true
+				if !cInfo.full.State.Running {
+					stoppedDependents = append(stoppedDependents, cName)
+				}
+				collect(cName[1:])
+				continue
+			}
+
+			// depends_on: only cascade same-stack dependents with restart:true
+			if !depEntry.Restart {
+				continue
+			}
+			if startedStack != "" && ContainerStack(cInfo.full.Config) != startedStack {
+				continue
+			}
+
 			seen[cName] = true
 			if !cInfo.full.State.Running {
 				stoppedDependents = append(stoppedDependents, cName)
@@ -406,4 +434,178 @@ func stripInternalDependsOnLabel(labels map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+// ---------------------------------------------------------------------------
+// Stack membership + restart-of-dependents
+//
+// docker-compose (pkg/compose/restart.go prepareRestartProject) restart
+// behavior, which we mirror:
+//   - depends_on entries with restart:true make the dependent restart together
+//     with the dependency (entries with restart:false are pruned from the
+//     graph before restarting)
+//   - network_mode / ipc / pid: service:X dependents MUST be re-created when
+//     the target restarts (their shared namespace dies) — compose handles this
+//     as an implicit edge, not via restart:true
+//   - everything runs in dependency order, dependencies first
+//
+// We additionally scope the cascade to containers of the SAME stack, so a
+// single restarted container does not rebuild unrelated containers that happen
+// to reference it.
+// ---------------------------------------------------------------------------
+
+// stackLabelCandidates are the label keys (in priority order) that Cosmos and
+// docker-compose use to mark a container's stack/project membership.
+var stackLabelCandidates = []string{
+	"cosmos-stack",      // dash variant (referenced by user + backups.go)
+	"cosmos.stack",      // dot variant (what the compose editor writes)
+	"cosmos.stack.main", // main marker
+	"cosmos-stack-main",
+	"com.docker.compose.project", // real docker-compose
+}
+
+// ContainerStack returns the stack/project name a container belongs to, or ""
+// if it is standalone. It accepts every variant Cosmos and compose use.
+func ContainerStack(conf *conttype.Config) string {
+	if conf == nil || conf.Labels == nil {
+		return ""
+	}
+	// main markers don't carry a name; look for the actual stack/project name
+	for _, key := range []string{"cosmos-stack", "cosmos.stack", "com.docker.compose.project"} {
+		if v := conf.Labels[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// containerStackMatches reports whether two container configs belong to the
+// same stack. A standalone container (no stack) matches nothing but itself.
+func containerStackMatches(a, b *conttype.Config) bool {
+	sa, sb := ContainerStack(a), ContainerStack(b)
+	if sa == "" || sb == "" {
+		return false
+	}
+	return sa == sb
+}
+
+// restartDependentsNeeded decides whether a dependent must be (re)started when
+// its dependency is restarted, mirroring docker-compose:
+//   - network_mode/ipc/pid namespace sharing => always restart
+//   - depends_on with restart:true            => restart
+//   - depends_on with restart:false           => no restart
+func restartDependentsNeeded(depEntry dependsOnEntry, networkMode string) bool {
+	if NetworkModeContainerRef(networkMode) || NetworkModeServiceRef(networkMode) {
+		return true
+	}
+	return depEntry.Restart
+}
+
+// RestartStackDependents restarts (or re-creates) every same-stack container
+// that depends on containerName, either through depends_on (restart:true) or
+// by sharing its network namespace (network_mode: container:/service:), in
+// dependency order. It mirrors docker-compose restart semantics and is scoped
+// to the stack to avoid surprising restarts of unrelated containers.
+//
+// Returns the names of containers it restarted (for logging/UI).
+func RestartStackDependents(containerName string) []string {
+	restarted := []string{}
+
+	target, err := DockerClient.ContainerInspect(DockerContext, containerName)
+	if err != nil {
+		utils.Error("RestartStackDependents: cannot inspect "+containerName, err)
+		return restarted
+	}
+	targetStack := ContainerStack(target.Config)
+	if targetStack == "" {
+		// no stack to scope against: only restart direct network_mode dependents
+		// anywhere (namespace sharing is independent of stack), but be safe and
+		// require the same stack like compose's project scope.
+		utils.Debug("RestartStackDependents: " + containerName + " is not part of a stack; nothing to cascade")
+		return restarted
+	}
+
+	containers, err := ListContainers()
+	if err != nil {
+		utils.Error("RestartStackDependents", err)
+		return restarted
+	}
+
+	// Build same-stack container set.
+	byName := map[string]depContainerInfo{}
+	for _, c := range containers {
+		full, err := DockerClient.ContainerInspect(DockerContext, c.ID)
+		if err != nil {
+			continue
+		}
+		if full.ID == target.ID {
+			continue
+		}
+		if ContainerStack(full.Config) != targetStack {
+			continue // scope to same stack
+		}
+		name := ""
+		if len(c.Names) > 0 {
+			name = c.Names[0]
+		} else if full.ContainerJSONBase != nil {
+			name = full.Name
+		}
+		if name == "" {
+			continue
+		}
+		byName[name] = depContainerInfo{full: full, name: name}
+	}
+
+	// Collect dependents.
+	dependentNames := []string{}
+	for name, cInfo := range byName {
+		full := cInfo.full
+		deps := DependsOnFromLabels(full.Config)
+		if entry, ok := deps[target.Name[1:]]; ok {
+			if restartDependentsNeeded(entry, string(full.HostConfig.NetworkMode)) {
+				utils.Log(fmt.Sprintf("RestartStackDependents: %s depends_on %s (restart=%t) -> restarting", name, target.Name[1:], entry.Restart))
+				dependentNames = append(dependentNames, name)
+			}
+			continue
+		}
+		// network_mode / ipc / pid namespace sharing (implicit edge)
+		nm := string(full.HostConfig.NetworkMode)
+		if NetworkModeContainerRef(nm) || NetworkModeServiceRef(nm) {
+			refTarget := NetworkModeRefTarget(nm)
+			if refTarget == target.Name[1:] || refTarget == target.ID {
+				utils.Log(fmt.Sprintf("RestartStackDependents: %s shares network namespace with %s -> restarting", name, target.Name[1:]))
+				dependentNames = append(dependentNames, name)
+			}
+			continue
+		}
+		// cosmos-force-network-mode label (durable network_mode reference)
+		labelMode := GetLabel(full, "cosmos-force-network-mode")
+		labelTarget := NetworkModeRefTarget(labelMode)
+		if labelTarget != "" && (labelTarget == target.Name[1:] || labelTarget == target.ID) {
+			utils.Log(fmt.Sprintf("RestartStackDependents: %s shares network namespace with %s (label) -> restarting", name, target.Name[1:]))
+			dependentNames = append(dependentNames, name)
+		}
+	}
+
+	if len(dependentNames) == 0 {
+		return restarted
+	}
+
+	// Restart in dependency order (dependencies first), respecting each
+	// dependent's own depends_on waits.
+	ordered := OrderByDependencies(dependentNames, depContainerConfigs(byName))
+	for _, name := range ordered {
+		full := byName[name].full
+		utils.Log(fmt.Sprintf("RestartStackDependents: restarting %s", name))
+		if errW := WaitForDependsOn(DockerContext, full.ID); errW != nil {
+			utils.Error("RestartStackDependents: dependency wait failed for "+name, errW)
+			continue
+		}
+		if errR := DockerClient.ContainerRestart(DockerContext, full.ID, conttype.StopOptions{}); errR != nil {
+			utils.Error("RestartStackDependents: cannot restart "+name, errR)
+			continue
+		}
+		restarted = append(restarted, name)
+	}
+	return restarted
 }

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -457,10 +457,8 @@ func stripInternalDependsOnLabel(labels map[string]string) map[string]string {
 // stackLabelCandidates are the label keys (in priority order) that Cosmos and
 // docker-compose use to mark a container's stack/project membership.
 var stackLabelCandidates = []string{
-	"cosmos-stack",      // dash variant (referenced by user + backups.go)
-	"cosmos.stack",      // dot variant (what the compose editor writes)
-	"cosmos.stack.main", // main marker
-	"cosmos-stack-main",
+	"cosmos.stack",              // what the compose editor writes
+	"cosmos.stack.main",         // main marker
 	"com.docker.compose.project", // real docker-compose
 }
 
@@ -471,7 +469,7 @@ func ContainerStack(conf *conttype.Config) string {
 		return ""
 	}
 	// main markers don't carry a name; look for the actual stack/project name
-	for _, key := range []string{"cosmos-stack", "cosmos.stack", "com.docker.compose.project"} {
+	for _, key := range []string{"cosmos.stack", "com.docker.compose.project"} {
 		if v := conf.Labels[key]; v != "" {
 			return v
 		}

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -368,3 +368,42 @@ func depContainerConfigs(byName map[string]depContainerInfo) map[string]doctype.
 	}
 	return out
 }
+
+// DependsOnFieldFromLabels converts the persisted compose depends_on label back
+// into the depends_on *field* shape (map[service]DependsOnCont) that Cosmos's
+// compose model exposes. This is what the user should see/edit: the field, not
+// the label. Mirrors compose.go's projectFromName reconstruction.
+func DependsOnFieldFromLabels(conf *conttype.Config) map[string]ContainerCreateRequestContainerDependsOnCont {
+	out := map[string]ContainerCreateRequestContainerDependsOnCont{}
+	if conf == nil || conf.Labels == nil {
+		return out
+	}
+	for dep, entry := range DependsOnFromLabels(conf) {
+		out[dep] = ContainerCreateRequestContainerDependsOnCont{
+			Condition: entry.Condition,
+			Restart:   strconv.FormatBool(entry.Restart),
+		}
+	}
+	return out
+}
+
+// stripInternalDependsOnLabel removes compose's internal
+// com.docker.compose.depends_on label from a labels map without mutating the
+// input. The label is an internal serialization detail: the source of truth
+// exposed to the user is the depends_on field.
+func stripInternalDependsOnLabel(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+	if _, ok := labels[composeDependenciesLabel]; !ok {
+		return labels
+	}
+	out := make(map[string]string, len(labels)-1)
+	for k, v := range labels {
+		if k == composeDependenciesLabel {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,86 +14,115 @@ import (
 	"github.com/azukaar/cosmos-server/src/utils"
 )
 
-// Container dependency conditions, mirroring docker-compose's depends_on
-// condition field. A dependency without an explicit condition is treated as
-// service_started (docker-compose default).
+// Dependency conditions, mirroring docker-compose's depends_on condition
+// field exactly (compose-go types.go). A dependency without an explicit
+// condition defaults to service_started, exactly like docker-compose.
 const (
-	DepConditionStarted          = "service_started"
+	DepConditionStarted          = "service_started"    // default
+	DepConditionRunningOrHealthy = "running_or_healthy" // compose CLI's implicit fallback
 	DepConditionHealthy          = "service_healthy"
 	DepConditionCompletedSuccess = "service_completed_successfully"
-
-	// Cosmos-native extension (same semantics as compose, different key so
-	// compose specs keep working unchanged).
-	depConditionRestart = "restart"
 )
 
-// Labels used to persist the dependency graph on the container itself so the
-// runtime restart/recreate paths (which go through EditContainer, not
-// CreateService) can honor depends_on too.
-const (
-	depLabelPrefix = "cosmos.depends_on."
-	depLabelList   = "cosmos.depends_on.list"
-)
+// composeDependenciesLabel is the SAME label docker-compose itself uses to
+// persist the depends_on field on each container
+// (pkg/api/labels.go: com.docker.compose.depends_on), value format:
+//
+//	"<service>:<condition>:<restart>,<service2>:<condition2>:<restart2>,..."
+//
+// Matching compose exactly means a stack that was created by docker-compose
+// and then imported into Cosmos keeps working, and vice-versa. This is the
+// only durable, per-container record of the depends_on graph (compose stores
+// it nowhere else).
+const composeDependenciesLabel = "com.docker.compose.depends_on"
 
-// dependencyTimeout is the maximum time we wait for a dependency condition
-// (service_healthy / service_completed_successfully) to be satisfied before
-// giving up. service_started only waits for the container to be running,
-// which is fast.
+// dependencyTimeout is the max time we wait for a dependency condition
+// (service_healthy / service_completed_successfully / running_or_healthy) to
+// be satisfied before giving up. service_started is NOT waited on here — it is
+// handled purely by the DAG start order, same as docker-compose
+// (waitDependencies returns immediately for ServiceConditionStarted).
 const dependencyTimeout = 10 * time.Minute
 
-func depLabelFor(service string) string {
-	return depLabelPrefix + service
+// DependsOnConfig mirrors compose-go's DependsOnConfig map value.
+type dependsOnEntry struct {
+	Condition string
+	Restart   bool
+	Required  bool
 }
 
-// ValidDepCondition reports whether cond is a condition value we understand.
-// Unknown conditions degrade to service_started (compose ignores unknown
-// values for ordering; we do the same but keep the value in labels so the
-// graph is still visible).
+// ValidDepCondition reports whether cond is a condition we understand.
 func ValidDepCondition(cond string) bool {
 	switch cond {
-	case DepConditionStarted, DepConditionHealthy, DepConditionCompletedSuccess, depConditionRestart:
+	case DepConditionStarted, DepConditionRunningOrHealthy, DepConditionHealthy, DepConditionCompletedSuccess:
 		return true
 	}
 	return false
 }
 
-// NormalizeDepCondition maps an empty/invalid condition to service_started.
+// NormalizeDepCondition maps an empty/unknown condition to service_started
+// (compose-default), with one exception: compose's CLI treats a missing/empty
+// condition as running_or_healthy (its `ServiceConditionRunningOrHealthy`
+// const). We keep empty => service_started when we WRITE the label (compose-go
+// writes whatever was parsed, default service_started), but when we READ back
+// a legacy label fragment without a condition we fall back to running_or_healthy
+// exactly like compose.go does.
 func NormalizeDepCondition(cond string) string {
+	if cond == "" {
+		return DepConditionStarted
+	}
 	if !ValidDepCondition(cond) {
 		return DepConditionStarted
 	}
 	return cond
 }
 
-// DependsOnFromLabels reconstructs the depends_on map from the labels Cosmos
-// writes at container creation. Returns an empty map when the container has
-// no dependency labels (the common case).
-func DependsOnFromLabels(conf *conttype.Config) map[string]string {
-	deps := map[string]string{}
+// DependsOnFromLabels reconstructs the depends_on map from a container's
+// Config.Labels, exactly like docker-compose's projectFromName does
+// (pkg/compose/compose.go). Returns an empty map when there is no label.
+func DependsOnFromLabels(conf *conttype.Config) map[string]dependsOnEntry {
+	deps := map[string]dependsOnEntry{}
 	if conf == nil || conf.Labels == nil {
 		return deps
 	}
 
-	list := conf.Labels[depLabelList]
-	if list == "" {
+	raw := conf.Labels[composeDependenciesLabel]
+	if raw == "" {
 		return deps
 	}
 
-	for _, service := range strings.Split(list, ",") {
-		service = strings.TrimSpace(service)
-		if service == "" {
+	for _, dc := range strings.Split(raw, ",") {
+		dc = strings.TrimSpace(dc)
+		if dc == "" {
 			continue
 		}
-		cond := conf.Labels[depLabelFor(service)]
-		deps[service] = NormalizeDepCondition(cond)
+		dcArr := strings.Split(dc, ":")
+		condition := DepConditionRunningOrHealthy
+		restart := true
+		required := true
+		dependency := dcArr[0]
+
+		if len(dcArr) > 1 {
+			condition = dcArr[1]
+			if len(dcArr) > 2 {
+				restart, _ = strconv.ParseBool(dcArr[2])
+			}
+		}
+
+		deps[dependency] = dependsOnEntry{
+			Condition: condition,
+			Restart:   restart,
+			Required:  required,
+		}
 	}
 	return deps
 }
 
-// SetDependsOnLabels writes the depends_on graph as labels on the container
-// config (mutating conf.Labels). Call this right before ContainerCreate so
-// the graph survives re-creates and can be inspected at runtime.
-func SetDependsOnLabels(conf *conttype.Config, deps map[string]string) {
+// SetDependsOnLabels writes the depends_on graph as compose's
+// com.docker.compose.depends_on label, in compose's own
+// "<svc>:<cond>:<restart>,..." format. Call this right before
+// ContainerCreate so the graph survives re-creates and can be inspected at
+// runtime (compose does the same).
+func SetDependsOnLabels(conf *conttype.Config, deps map[string]dependsOnEntry) {
 	if conf == nil {
 		return
 	}
@@ -106,48 +136,69 @@ func SetDependsOnLabels(conf *conttype.Config, deps map[string]string) {
 	}
 	sort.Strings(keys)
 
-	conf.Labels[depLabelList] = strings.Join(keys, ",")
+	parts := make([]string, 0, len(keys))
 	for _, service := range keys {
-		conf.Labels[depLabelFor(service)] = NormalizeDepCondition(deps[service])
+		d := deps[service]
+		if d.Condition == "" {
+			d.Condition = DepConditionStarted
+		}
+		parts = append(parts, fmt.Sprintf("%s:%s:%t", service, d.Condition, d.Restart))
 	}
+	conf.Labels[composeDependenciesLabel] = strings.Join(parts, ",")
+}
+
+// DepConditions returns the map service->condition for convenience (used by
+// the HTTP/ordering layer).
+func DepConditions(conf *conttype.Config) map[string]string {
+	out := map[string]string{}
+	for k, v := range DependsOnFromLabels(conf) {
+		out[k] = v.Condition
+	}
+	return out
 }
 
 // depConditionMet reports whether dep (as currently inspected) satisfies the
-// condition cond. state may be nil for a container that no longer exists.
+// condition cond. Models compose's isServiceHealthy / isServiceCompleted.
 func depConditionMet(dep doctype.ContainerJSON, cond string) bool {
-	if cond == "" {
-		cond = DepConditionStarted
-	}
-
 	if dep.ContainerJSONBase == nil || dep.State == nil {
 		return false
 	}
 
 	switch cond {
-	case DepConditionStarted:
-		return dep.State.Running
-	case DepConditionHealthy:
-		if !dep.State.Running {
+	case DepConditionStarted, DepConditionRunningOrHealthy:
+		// compose's checkDependencyRunningOrHealthy: healthy if running, or
+		// falls back to "running" when there's no healthcheck.
+		if dep.State.Status == "exited" {
 			return false
 		}
-		// A container without a healthcheck never becomes "healthy"; treat it
-		// as healthy once it is running (same as compose's service_healthy
-		// behavior for healthcheck-less images).
-		if dep.Config == nil || dep.Config.Healthcheck == nil {
-			return true
+		noHealthcheck := dep.Config == nil || dep.Config.Healthcheck == nil ||
+			(len(dep.Config.Healthcheck.Test) > 0 && dep.Config.Healthcheck.Test[0] == "NONE")
+		if noHealthcheck {
+			return dep.State.Running
+		}
+		return dep.State.Health != nil && dep.State.Health.Status == doctype.Healthy
+	case DepConditionHealthy:
+		if dep.State.Status == "exited" {
+			return false
+		}
+		if dep.Config == nil || dep.Config.Healthcheck == nil ||
+			(len(dep.Config.Healthcheck.Test) > 0 && dep.Config.Healthcheck.Test[0] == "NONE") {
+			// compose with fallbackRunning=false errors; for robustness treat a
+			// healthcheck-less running container as unhealthy-ish but keep
+			// waiting is wrong -> treat as not-met so dependent keeps waiting.
+			return false
 		}
 		return dep.State.Health != nil && dep.State.Health.Status == doctype.Healthy
 	case DepConditionCompletedSuccess:
 		return !dep.State.Running && dep.State.ExitCode == 0
 	default:
-		// Unknown condition: fall back to started.
 		return dep.State.Running
 	}
 }
 
 // WaitForDepCondition polls depName until cond is met, or returns an error
-// after dependencyTimeout. A missing dependency is an error (mirrors compose
-// depending on a service that does not exist).
+// after dependencyTimeout. A missing dependency is an error (compose:
+// "%s is missing dependency %s").
 func WaitForDepCondition(ctx context.Context, depName string, cond string) error {
 	if cond == "" {
 		cond = DepConditionStarted
@@ -173,10 +224,10 @@ func WaitForDepCondition(ctx context.Context, depName string, cond string) error
 }
 
 // WaitForDependsOn waits for every dependency of containerName, using the
-// dependency graph persisted on the container's labels. It is used by the
-// runtime paths (restart / recreate / update) that do not go through
-// CreateService's pre-start ordering. Missing dependency containers are
-// considered an error and surfaced.
+// depends_on graph persisted on the container's compose label. It is used by
+// the runtime paths (restart / recreate / update). mirroring compose, only
+// conditions other than service_started are waited on: service_started is
+// already guaranteed by start ordering.
 func WaitForDependsOn(ctx context.Context, containerName string) error {
 	current, err := DockerClient.ContainerInspect(ctx, containerName)
 	if err != nil {
@@ -188,18 +239,28 @@ func WaitForDependsOn(ctx context.Context, containerName string) error {
 		return nil
 	}
 
-	// Deterministic order (sorted labels) so logs are stable.
+	// Deterministic order (sorted) so logs are stable.
 	names := make([]string, 0, len(deps))
 	for name := range deps {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
-	utils.Log(fmt.Sprintf("depends_on: container %s waiting for %d dependencies: %s",
-		containerName, len(names), strings.Join(names, ", ")))
+	waiting := []string{}
+	for _, name := range names {
+		if deps[name].Condition != DepConditionStarted {
+			waiting = append(waiting, name)
+		}
+	}
+	if len(waiting) == 0 {
+		return nil
+	}
 
-	for _, depName := range names {
-		cond := deps[depName]
+	utils.Log(fmt.Sprintf("depends_on: container %s waiting for %d dependencies: %s",
+		containerName, len(waiting), strings.Join(waiting, ", ")))
+
+	for _, depName := range waiting {
+		cond := deps[depName].Condition
 		utils.Log(fmt.Sprintf("depends_on: waiting for %s (%s)", depName, cond))
 		if err := WaitForDepCondition(ctx, depName, cond); err != nil {
 			return err
@@ -210,15 +271,11 @@ func WaitForDependsOn(ctx context.Context, containerName string) error {
 
 // ReorderDependedOn is the boot-up cascade: after containerID starts, any
 // container whose depends_on graph references it (directly or transitively)
-// gets started again in dependency order. Docker knows nothing about
-// depends_on, so without this a dependent that crashed (or never started on
-// boot) would stay down even though its dependency is back.
-//
-// It is deliberately best-effort and non-blocking:
-//   - only containers that are stopped AND depend on containerID are started;
-//     running dependents are left alone (no restarts, no churn)
-//   - failures are logged, never fatal
-//   - runs in its own goroutine (see onDockerStarted)
+// gets started again in dependency order, plus any stopped container that
+// shares its network namespace (network_mode: container:) since that reference
+// requires the target to exist. Best-effort and non-blocking: running
+// dependents are left alone, failures are logged not fatal, runs in its own
+// goroutine (see onDockerStarted).
 func ReorderDependedOn(containerID string) {
 	startedName := ""
 	started, err := DockerClient.ContainerInspect(DockerContext, containerID)
@@ -232,7 +289,6 @@ func ReorderDependedOn(containerID string) {
 		return
 	}
 
-	// Build a name -> (config, stopped?, running?) map once.
 	byName := map[string]depContainerInfo{}
 	for _, c := range containers {
 		full, err := DockerClient.ContainerInspect(DockerContext, c.ID)
@@ -251,18 +307,20 @@ func ReorderDependedOn(containerID string) {
 		byName[name] = depContainerInfo{full: full, name: name}
 	}
 
-	// Find all containers that (transitively) depend on the started one and
-	// are currently stopped.
+	// Find containers that (transitively) depend on the started one, or share
+	// its network namespace, and are currently stopped.
 	stoppedDependents := []string{}
 	seen := map[string]bool{}
-	var collect func(name string)
+	var collect func(depName string)
 	collect = func(depName string) {
 		for cName, cInfo := range byName {
 			if seen[cName] {
 				continue
 			}
 			deps := DependsOnFromLabels(cInfo.full.Config)
-			if _, ok := deps[depName]; !ok {
+			_, hasDep := deps[depName]
+			sharesNetNS := strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "container:"+depName)
+			if !hasDep && !sharesNetNS {
 				continue
 			}
 			seen[cName] = true
@@ -281,7 +339,6 @@ func ReorderDependedOn(containerID string) {
 
 	utils.Log(fmt.Sprintf("ReorderDependedOn: %s started; waking %d stopped dependents", startedName, len(stoppedDependents)))
 
-	// Start them in dependency order, waiting for each one's own deps.
 	ordered := OrderByDependencies(stoppedDependents, depContainerConfigs(byName))
 	for _, name := range ordered {
 		cInfo := byName[name]

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -43,14 +43,13 @@ const composeDependenciesLabel = "com.docker.compose.depends_on"
 // (waitDependencies returns immediately for ServiceConditionStarted).
 const dependencyTimeout = 10 * time.Minute
 
-// DependsOnConfig mirrors compose-go's DependsOnConfig map value.
+// dependsOnEntry is one entry of the persisted depends_on graph.
 type dependsOnEntry struct {
 	Condition string
 	Restart   bool
-	Required  bool
 }
 
-// ValidDepCondition reports whether cond is a condition we understand.
+// ValidDepCondition reports whether cond is a supported depends_on condition.
 func ValidDepCondition(cond string) bool {
 	switch cond {
 	case DepConditionStarted, DepConditionRunningOrHealthy, DepConditionHealthy, DepConditionCompletedSuccess:
@@ -60,17 +59,10 @@ func ValidDepCondition(cond string) bool {
 }
 
 // NormalizeDepCondition maps an empty/unknown condition to service_started
-// (compose-default), with one exception: compose's CLI treats a missing/empty
-// condition as running_or_healthy (its `ServiceConditionRunningOrHealthy`
-// const). We keep empty => service_started when we WRITE the label (compose-go
-// writes whatever was parsed, default service_started), but when we READ back
-// a legacy label fragment without a condition we fall back to running_or_healthy
-// exactly like compose.go does.
+// (compose default when writing; legacy label fragments without a condition
+// are read back as running_or_healthy in DependsOnFromLabels).
 func NormalizeDepCondition(cond string) string {
-	if cond == "" {
-		return DepConditionStarted
-	}
-	if !ValidDepCondition(cond) {
+	if cond == "" || !ValidDepCondition(cond) {
 		return DepConditionStarted
 	}
 	return cond
@@ -98,7 +90,6 @@ func DependsOnFromLabels(conf *conttype.Config) map[string]dependsOnEntry {
 		dcArr := strings.Split(dc, ":")
 		condition := DepConditionRunningOrHealthy
 		restart := true
-		required := true
 		dependency := dcArr[0]
 
 		if len(dcArr) > 1 {
@@ -108,11 +99,7 @@ func DependsOnFromLabels(conf *conttype.Config) map[string]dependsOnEntry {
 			}
 		}
 
-		deps[dependency] = dependsOnEntry{
-			Condition: condition,
-			Restart:   restart,
-			Required:  required,
-		}
+		deps[dependency] = dependsOnEntry{Condition: condition, Restart: restart}
 	}
 	return deps
 }
@@ -147,18 +134,7 @@ func SetDependsOnLabels(conf *conttype.Config, deps map[string]dependsOnEntry) {
 	conf.Labels[composeDependenciesLabel] = strings.Join(parts, ",")
 }
 
-// DepConditions returns the map service->condition for convenience (used by
-// the HTTP/ordering layer).
-func DepConditions(conf *conttype.Config) map[string]string {
-	out := map[string]string{}
-	for k, v := range DependsOnFromLabels(conf) {
-		out[k] = v.Condition
-	}
-	return out
-}
-
-// depConditionMet reports whether dep (as currently inspected) satisfies the
-// condition cond. Models compose's isServiceHealthy / isServiceCompleted.
+// depConditionMet reports whether dep satisfies condition cond.
 func depConditionMet(dep doctype.ContainerJSON, cond string) bool {
 	if dep.ContainerJSONBase == nil || dep.State == nil {
 		return false
@@ -166,14 +142,11 @@ func depConditionMet(dep doctype.ContainerJSON, cond string) bool {
 
 	switch cond {
 	case DepConditionStarted, DepConditionRunningOrHealthy:
-		// compose's checkDependencyRunningOrHealthy: healthy if running, or
-		// falls back to "running" when there's no healthcheck.
 		if dep.State.Status == "exited" {
 			return false
 		}
-		noHealthcheck := dep.Config == nil || dep.Config.Healthcheck == nil ||
-			(len(dep.Config.Healthcheck.Test) > 0 && dep.Config.Healthcheck.Test[0] == "NONE")
-		if noHealthcheck {
+		// no healthcheck => running counts as satisfied (compose fallback)
+		if !depHasHealthcheck(dep) {
 			return dep.State.Running
 		}
 		return dep.State.Health != nil && dep.State.Health.Status == doctype.Healthy
@@ -181,11 +154,8 @@ func depConditionMet(dep doctype.ContainerJSON, cond string) bool {
 		if dep.State.Status == "exited" {
 			return false
 		}
-		if dep.Config == nil || dep.Config.Healthcheck == nil ||
-			(len(dep.Config.Healthcheck.Test) > 0 && dep.Config.Healthcheck.Test[0] == "NONE") {
-			// compose with fallbackRunning=false errors; for robustness treat a
-			// healthcheck-less running container as unhealthy-ish but keep
-			// waiting is wrong -> treat as not-met so dependent keeps waiting.
+		// a healthcheck-less container never satisfies service_healthy
+		if !depHasHealthcheck(dep) {
 			return false
 		}
 		return dep.State.Health != nil && dep.State.Health.Status == doctype.Healthy
@@ -196,9 +166,16 @@ func depConditionMet(dep doctype.ContainerJSON, cond string) bool {
 	}
 }
 
-// WaitForDepCondition polls depName until cond is met, or returns an error
-// after dependencyTimeout. A missing dependency is an error (compose:
-// "%s is missing dependency %s").
+// depHasHealthcheck reports whether dep declares an active healthcheck.
+func depHasHealthcheck(dep doctype.ContainerJSON) bool {
+	if dep.Config == nil || dep.Config.Healthcheck == nil {
+		return false
+	}
+	return len(dep.Config.Healthcheck.Test) == 0 || dep.Config.Healthcheck.Test[0] != "NONE"
+}
+
+// WaitForDepCondition polls depName until cond is met or dependencyTimeout
+// elapses. A missing dependency is an error (compose parity).
 func WaitForDepCondition(ctx context.Context, depName string, cond string) error {
 	if cond == "" {
 		cond = DepConditionStarted
@@ -223,11 +200,8 @@ func WaitForDepCondition(ctx context.Context, depName string, cond string) error
 	}
 }
 
-// WaitForDependsOn waits for every dependency of containerName, using the
-// depends_on graph persisted on the container's compose label. It is used by
-// the runtime paths (restart / recreate / update). mirroring compose, only
-// conditions other than service_started are waited on: service_started is
-// already guaranteed by start ordering.
+// WaitForDependsOn waits for containerName's dependencies (runtime restart /
+// recreate paths). Only conditions other than service_started are waited on.
 func WaitForDependsOn(ctx context.Context, containerName string) error {
 	current, err := DockerClient.ContainerInspect(ctx, containerName)
 	if err != nil {
@@ -274,13 +248,9 @@ func WaitForDependsOn(ctx context.Context, containerName string) error {
 	return nil
 }
 
-// ReorderDependedOn is the boot-up cascade: after containerID starts, any
-// container whose depends_on graph references it (directly or transitively)
-// gets started again in dependency order, plus any stopped container that
-// shares its network namespace (network_mode: container:) since that reference
-// requires the target to exist. Best-effort and non-blocking: running
-// dependents are left alone, failures are logged not fatal, runs in its own
-// goroutine (see onDockerStarted).
+// ReorderDependedOn starts stopped dependents (depends_on restart:true or
+// network_mode sharers) after containerID starts — best-effort, non-blocking,
+// same-stack scoped. Called from onDockerStarted.
 func ReorderDependedOn(containerID string) {
 	startedName := ""
 	started, err := DockerClient.ContainerInspect(DockerContext, containerID)
@@ -288,43 +258,17 @@ func ReorderDependedOn(containerID string) {
 		startedName = started.Name[1:]
 	}
 
-	containers, err := ListContainers()
-	if err != nil {
-		utils.Debug("ReorderDependedOn: cannot list containers: " + err.Error())
-		return
-	}
-
-	byName := map[string]depContainerInfo{}
-	for _, c := range containers {
-		full, err := DockerClient.ContainerInspect(DockerContext, c.ID)
-		if err != nil {
-			continue
-		}
-		name := ""
-		if len(c.Names) > 0 {
-			name = c.Names[0]
-		} else if full.ContainerJSONBase != nil {
-			name = full.Name
-		}
-		if name == "" {
-			continue
-		}
-		byName[name] = depContainerInfo{full: full, name: name}
-	}
-
-	// Find containers that (transitively) depend on the started one, or share
-	// its network namespace, and are currently stopped. Scoped to the same
-	// stack, and only depends_on entries with restart:true or network_mode
-	// references are honored (docker-compose parity).
 	startedStack := ""
 	if started.ContainerJSONBase != nil && started.Config != nil {
 		startedStack = ContainerStack(started.Config)
 	}
 
+	// network_mode sharers may live outside the started one's stack
+	byName := buildSameStackIndex("", "")
+
 	stoppedDependents := []string{}
 	seen := map[string]bool{}
-	// targetService is the started container's compose service name (for
-	// matching depends_on keys that docker-compose stores by service name).
+	// compose service name for matching service-keyed depends_on
 	startedService := ""
 	if started.ContainerJSONBase != nil && started.Config != nil && started.Config.Labels != nil {
 		startedService = started.Config.Labels["com.docker.compose.service"]
@@ -342,8 +286,6 @@ func ReorderDependedOn(containerID string) {
 		return n, ""
 	}
 
-	// collect starts from the started container and walks dependents whose
-	// depends_on (by container name OR service name) matches.
 	var collect func(depName, depService string)
 	collect = func(depName, depService string) {
 		for cName, cInfo := range byName {
@@ -412,7 +354,7 @@ func ReorderDependedOn(containerID string) {
 	}
 }
 
-// depContainerInfo carries the few fields ReorderDependedOn needs per container.
+// depContainerInfo carries the fields the dependents-cascade functions need.
 type depContainerInfo struct {
 	full doctype.ContainerJSON
 	name string
@@ -428,19 +370,48 @@ func depContainerConfigs(byName map[string]depContainerInfo) map[string]doctype.
 	return out
 }
 
+// buildSameStackIndex lists every container in stack (excluding excludeID),
+// keyed by container name. Used by the depends_on / network_mode cascades.
+func buildSameStackIndex(stack, excludeID string) map[string]depContainerInfo {
+	byName := map[string]depContainerInfo{}
+	containers, err := ListContainers()
+	if err != nil {
+		utils.Debug("buildSameStackIndex: cannot list containers: " + err.Error())
+		return byName
+	}
+	for _, c := range containers {
+		full, err := DockerClient.ContainerInspect(DockerContext, c.ID)
+		if err != nil || full.ID == excludeID {
+			continue
+		}
+		if stack != "" && ContainerStack(full.Config) != stack {
+			continue
+		}
+		name := ""
+		if len(c.Names) > 0 {
+			name = c.Names[0]
+		} else if full.ContainerJSONBase != nil {
+			name = full.Name
+		}
+		if name != "" {
+			byName[name] = depContainerInfo{full: full, name: name}
+		}
+	}
+	return byName
+}
+
 // DependsOnFieldFromLabels converts the persisted compose depends_on label back
 // into the depends_on *field* shape (map[service]DependsOnCont) that Cosmos's
 // compose model exposes. This is what the user should see/edit: the field, not
 // the label. Mirrors compose.go's projectFromName reconstruction.
-func DependsOnFieldFromLabels(conf *conttype.Config) map[string]ContainerCreateRequestContainerDependsOnCont {
+// DependsOnFieldFromLabels converts the persisted depends_on label into the
+// depends_on *field* shape, resolving service-name keys to container names via
+// idx (may be nil when no container index is available).
+func DependsOnFieldFromLabels(conf *conttype.Config, idx *containerNameIndex) map[string]ContainerCreateRequestContainerDependsOnCont {
 	out := map[string]ContainerCreateRequestContainerDependsOnCont{}
 	if conf == nil || conf.Labels == nil {
 		return out
 	}
-	// Resolve docker-compose SERVICE-name keys to CONTAINER names so the field
-	// shown to the user (and round-tripped into Cosmos) uses the same
-	// container-name convention Cosmos expects.
-	idx := buildContainerNameIndex()
 	for dep, entry := range DependsOnFromLabels(conf) {
 		out[resolveDepKey(idx, dep)] = ContainerCreateRequestContainerDependsOnCont{
 			Condition: entry.Condition,
@@ -472,54 +443,23 @@ func stripInternalDependsOnLabel(labels map[string]string) map[string]string {
 }
 
 // ---------------------------------------------------------------------------
-// Stack membership + restart-of-dependents
-//
-// docker-compose (pkg/compose/restart.go prepareRestartProject) restart
-// behavior, which we mirror:
-//   - depends_on entries with restart:true make the dependent restart together
-//     with the dependency (entries with restart:false are pruned from the
-//     graph before restarting)
-//   - network_mode / ipc / pid: service:X dependents MUST be re-created when
-//     the target restarts (their shared namespace dies) — compose handles this
-//     as an implicit edge, not via restart:true
-//   - everything runs in dependency order, dependencies first
-//
-// We additionally scope the cascade to containers of the SAME stack, so a
-// single restarted container does not rebuild unrelated containers that happen
-// to reference it.
+// Restart-of-dependents (docker-compose parity, pkg/compose/restart.go):
+//   - depends_on with restart:false is pruned; restart:true restarts together
+//   - network_mode/ipc/pid namespace sharers always restart (namespace died)
+//   - everything runs in dependency order, scoped to the same stack
 // ---------------------------------------------------------------------------
 
-// stackLabelCandidates are the label keys (in priority order) that Cosmos and
-// docker-compose use to mark a container's stack/project membership.
-var stackLabelCandidates = []string{
-	"cosmos.stack",               // what the compose editor writes
-	"cosmos.stack.main",          // main marker
-	"com.docker.compose.project", // real docker-compose
-}
-
-// ContainerStack returns the stack/project name a container belongs to, or ""
-// if it is standalone. It accepts every variant Cosmos and compose use.
+// ContainerStack returns the stack/project name a container belongs to, or "".
 func ContainerStack(conf *conttype.Config) string {
 	if conf == nil || conf.Labels == nil {
 		return ""
 	}
-	// main markers don't carry a name; look for the actual stack/project name
 	for _, key := range []string{"cosmos.stack", "com.docker.compose.project"} {
 		if v := conf.Labels[key]; v != "" {
 			return v
 		}
 	}
 	return ""
-}
-
-// containerStackMatches reports whether two container configs belong to the
-// same stack. A standalone container (no stack) matches nothing but itself.
-func containerStackMatches(a, b *conttype.Config) bool {
-	sa, sb := ContainerStack(a), ContainerStack(b)
-	if sa == "" || sb == "" {
-		return false
-	}
-	return sa == sb
 }
 
 // restartDependentsNeeded decides whether a dependent must be (re)started when
@@ -534,13 +474,9 @@ func restartDependentsNeeded(depEntry dependsOnEntry, networkMode string) bool {
 	return depEntry.Restart
 }
 
-// RestartStackDependents restarts (or re-creates) every same-stack container
-// that depends on containerName, either through depends_on (restart:true) or
-// by sharing its network namespace (network_mode: container:/service:), in
-// dependency order. It mirrors docker-compose restart semantics and is scoped
-// to the stack to avoid surprising restarts of unrelated containers.
-//
-// Returns the names of containers it restarted (for logging/UI).
+// RestartStackDependents restarts same-stack dependents of containerName:
+// network_mode sharers (always) and depends_on restart:true, in dependency
+// order. Returns the names it restarted.
 func RestartStackDependents(containerName string) []string {
 	restarted := []string{}
 
@@ -551,43 +487,12 @@ func RestartStackDependents(containerName string) []string {
 	}
 	targetStack := ContainerStack(target.Config)
 	if targetStack == "" {
-		// no stack to scope against: only restart direct network_mode dependents
-		// anywhere (namespace sharing is independent of stack), but be safe and
-		// require the same stack like compose's project scope.
 		utils.Debug("RestartStackDependents: " + containerName + " is not part of a stack; nothing to cascade")
 		return restarted
 	}
 
-	containers, err := ListContainers()
-	if err != nil {
-		utils.Error("RestartStackDependents", err)
-		return restarted
-	}
-
-	// Build same-stack container set.
-	byName := map[string]depContainerInfo{}
-	for _, c := range containers {
-		full, err := DockerClient.ContainerInspect(DockerContext, c.ID)
-		if err != nil {
-			continue
-		}
-		if full.ID == target.ID {
-			continue
-		}
-		if ContainerStack(full.Config) != targetStack {
-			continue // scope to same stack
-		}
-		name := ""
-		if len(c.Names) > 0 {
-			name = c.Names[0]
-		} else if full.ContainerJSONBase != nil {
-			name = full.Name
-		}
-		if name == "" {
-			continue
-		}
-		byName[name] = depContainerInfo{full: full, name: name}
-	}
+	// same-stack dependents only (network_mode sharers included via stack scope)
+	byName := buildSameStackIndex(targetStack, target.ID)
 
 	// Collect dependents.
 	targetService := ""
@@ -649,30 +554,17 @@ func RestartStackDependents(containerName string) []string {
 }
 
 // ---------------------------------------------------------------------------
-// service-name <-> container-name resolution
+// Service-name <-> container-name resolution.
 //
-// docker-compose persists depends_on using SERVICE names (its label
-// com.docker.compose.depends_on = "svc:cond:restart,..."), and tags every
-// container with com.docker.compose.service = <service name>. Cosmos, on the
-// other hand, writes depends_on using CONTAINER names (the compose editor
-// rewrites service keys to container names at import). So a stack created by
-// real docker-compose and then recreated in Cosmos would fail because Cosmos
-// looked up a container by the service name.
-//
-// ResolveDepKey is the compatibility wrapper: given a depends_on key, it
-// returns the container name that key refers to, trying, in order:
-//   1. the key as-is, if a container by that name exists (Cosmos-created)
-//   2. the container whose com.docker.compose.service label == key
-//      (docker-compose-created)
-//   3. the key unchanged (caller surfaces the error)
-//
-// It caches the container list per call, so it is safe to call repeatedly.
+// docker-compose persists depends_on with SERVICE names and tags each
+// container with com.docker.compose.service = <service>; Cosmos uses CONTAINER
+// names (the compose editor rewrites service keys to container names at
+// import). ResolveDepKey(resolveDepKey) bridges the two: a depends_on key is
+// first looked up as a container name, then as a service label.
 // ---------------------------------------------------------------------------
 
-// listContainersByName returns name (no leading "/") -> container, plus
-// service-name (com.docker.compose.service) -> container, for every container.
-// This is the lookup base for ResolveDepKey. It includes stopped containers so
-// a stopped dependency can still be resolved.
+// containerNameIndex maps container names and compose service names to
+// containers (including stopped ones).
 type containerNameIndex struct {
 	byName    map[string]doctype.ContainerJSON
 	byService map[string]doctype.ContainerJSON
@@ -713,10 +605,8 @@ func buildContainerNameIndex() *containerNameIndex {
 	return idx
 }
 
-// resolveDepKey maps a depends_on key (service name, as docker-compose stores
-// it) to the container name it refers to, using a prebuilt index. If key is
-// already a container name it is returned unchanged. Falls back to the key
-// itself when unresolvable.
+// resolveDepKey maps a depends_on key to the container name it refers to,
+// falling back to the key itself when unresolvable.
 func resolveDepKey(idx *containerNameIndex, key string) string {
 	if idx == nil {
 		return key
@@ -734,13 +624,6 @@ func resolveDepKey(idx *containerNameIndex, key string) string {
 		}
 	}
 	return key
-}
-
-// ResolveDepKey maps a depends_on key (service name, as docker-compose stores
-// it) to the container name it refers to. If key is already a container name
-// it is returned unchanged. Falls back to the key itself when unresolvable.
-func ResolveDepKey(key string) string {
-	return resolveDepKey(buildContainerNameIndex(), key)
 }
 
 // DependsOnIncludesTarget reports whether deps (a depends_on map keyed by

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -454,7 +454,7 @@ func ContainerStack(conf *conttype.Config) string {
 	if conf == nil || conf.Labels == nil {
 		return ""
 	}
-	for _, key := range []string{"cosmos.stack", "com.docker.compose.project"} {
+	for _, key := range []string{"cosmos-stack", "cosmos.stack", "com.docker.compose.project"} {
 		if v := conf.Labels[key]; v != "" {
 			return v
 		}

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -239,17 +239,21 @@ func WaitForDependsOn(ctx context.Context, containerName string) error {
 		return nil
 	}
 
+	// Build the lookup index once (service name -> container name) so keys
+	// that docker-compose stored by SERVICE name resolve to CONTAINER names.
+	idx := buildContainerNameIndex()
+
 	// Deterministic order (sorted) so logs are stable.
-	names := make([]string, 0, len(deps))
-	for name := range deps {
-		names = append(names, name)
+	keys := make([]string, 0, len(deps))
+	for k := range deps {
+		keys = append(keys, k)
 	}
-	sort.Strings(names)
+	sort.Strings(keys)
 
 	waiting := []string{}
-	for _, name := range names {
-		if deps[name].Condition != DepConditionStarted {
-			waiting = append(waiting, name)
+	for _, key := range keys {
+		if deps[key].Condition != DepConditionStarted {
+			waiting = append(waiting, key)
 		}
 	}
 	if len(waiting) == 0 {
@@ -259,8 +263,9 @@ func WaitForDependsOn(ctx context.Context, containerName string) error {
 	utils.Log(fmt.Sprintf("depends_on: container %s waiting for %d dependencies: %s",
 		containerName, len(waiting), strings.Join(waiting, ", ")))
 
-	for _, depName := range waiting {
-		cond := deps[depName].Condition
+	for _, depKey := range waiting {
+		cond := deps[depKey].Condition
+		depName := resolveDepKey(idx, depKey)
 		utils.Log(fmt.Sprintf("depends_on: waiting for %s (%s)", depName, cond))
 		if err := WaitForDepCondition(ctx, depName, cond); err != nil {
 			return err
@@ -318,16 +323,40 @@ func ReorderDependedOn(containerID string) {
 
 	stoppedDependents := []string{}
 	seen := map[string]bool{}
-	var collect func(depName string)
-	collect = func(depName string) {
+	// targetService is the started container's compose service name (for
+	// matching depends_on keys that docker-compose stores by service name).
+	startedService := ""
+	if started.ContainerJSONBase != nil && started.Config != nil && started.Config.Labels != nil {
+		startedService = started.Config.Labels["com.docker.compose.service"]
+	}
+
+	// resolveName returns (containerName, serviceName) identity for recursion
+	resolveIdent := func(n string) (string, string) {
+		if full, ok := byName["/"+n]; ok {
+			svc := ""
+			if full.full.Config != nil && full.full.Config.Labels != nil {
+				svc = full.full.Config.Labels["com.docker.compose.service"]
+			}
+			return n, svc
+		}
+		return n, ""
+	}
+
+	// collect starts from the started container and walks dependents whose
+	// depends_on (by container name OR service name) matches.
+	var collect func(depName, depService string)
+	collect = func(depName, depService string) {
 		for cName, cInfo := range byName {
 			if seen[cName] {
 				continue
 			}
 			deps := DependsOnFromLabels(cInfo.full.Config)
-			depEntry, hasDep := deps[depName]
+			depEntry, hasDep := DependsOnIncludesTarget(deps, depName, depService)
+			// network_mode may reference by container name or service name
 			sharesNetNS := strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "container:"+depName) ||
-				strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "service:"+depName)
+				strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "service:"+depName) ||
+				(depService != "" && (strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "container:"+depService) ||
+					strings.HasPrefix(string(cInfo.full.HostConfig.NetworkMode), "service:"+depService)))
 			if !hasDep && !sharesNetNS {
 				continue
 			}
@@ -339,7 +368,8 @@ func ReorderDependedOn(containerID string) {
 				if !cInfo.full.State.Running {
 					stoppedDependents = append(stoppedDependents, cName)
 				}
-				collect(cName[1:])
+				n, svc := resolveIdent(cName[1:])
+				collect(n, svc)
 				continue
 			}
 
@@ -355,10 +385,11 @@ func ReorderDependedOn(containerID string) {
 			if !cInfo.full.State.Running {
 				stoppedDependents = append(stoppedDependents, cName)
 			}
-			collect(cName[1:]) // transitive
+			n, svc := resolveIdent(cName[1:])
+			collect(n, svc) // transitive
 		}
 	}
-	collect(startedName)
+	collect(startedName, startedService)
 
 	if len(stoppedDependents) == 0 {
 		utils.Debug("ReorderDependedOn: no stopped dependents for " + startedName)
@@ -406,8 +437,12 @@ func DependsOnFieldFromLabels(conf *conttype.Config) map[string]ContainerCreateR
 	if conf == nil || conf.Labels == nil {
 		return out
 	}
+	// Resolve docker-compose SERVICE-name keys to CONTAINER names so the field
+	// shown to the user (and round-tripped into Cosmos) uses the same
+	// container-name convention Cosmos expects.
+	idx := buildContainerNameIndex()
 	for dep, entry := range DependsOnFromLabels(conf) {
-		out[dep] = ContainerCreateRequestContainerDependsOnCont{
+		out[resolveDepKey(idx, dep)] = ContainerCreateRequestContainerDependsOnCont{
 			Condition: entry.Condition,
 			Restart:   strconv.FormatBool(entry.Restart),
 		}
@@ -457,8 +492,8 @@ func stripInternalDependsOnLabel(labels map[string]string) map[string]string {
 // stackLabelCandidates are the label keys (in priority order) that Cosmos and
 // docker-compose use to mark a container's stack/project membership.
 var stackLabelCandidates = []string{
-	"cosmos.stack",              // what the compose editor writes
-	"cosmos.stack.main",         // main marker
+	"cosmos.stack",               // what the compose editor writes
+	"cosmos.stack.main",          // main marker
 	"com.docker.compose.project", // real docker-compose
 }
 
@@ -555,11 +590,16 @@ func RestartStackDependents(containerName string) []string {
 	}
 
 	// Collect dependents.
+	targetService := ""
+	if target.Config != nil && target.Config.Labels != nil {
+		targetService = target.Config.Labels["com.docker.compose.service"]
+	}
+
 	dependentNames := []string{}
 	for name, cInfo := range byName {
 		full := cInfo.full
 		deps := DependsOnFromLabels(full.Config)
-		if entry, ok := deps[target.Name[1:]]; ok {
+		if entry, ok := DependsOnIncludesTarget(deps, target.Name[1:], targetService); ok {
 			if restartDependentsNeeded(entry, string(full.HostConfig.NetworkMode)) {
 				utils.Log(fmt.Sprintf("RestartStackDependents: %s depends_on %s (restart=%t) -> restarting", name, target.Name[1:], entry.Restart))
 				dependentNames = append(dependentNames, name)
@@ -606,4 +646,115 @@ func RestartStackDependents(containerName string) []string {
 		restarted = append(restarted, name)
 	}
 	return restarted
+}
+
+// ---------------------------------------------------------------------------
+// service-name <-> container-name resolution
+//
+// docker-compose persists depends_on using SERVICE names (its label
+// com.docker.compose.depends_on = "svc:cond:restart,..."), and tags every
+// container with com.docker.compose.service = <service name>. Cosmos, on the
+// other hand, writes depends_on using CONTAINER names (the compose editor
+// rewrites service keys to container names at import). So a stack created by
+// real docker-compose and then recreated in Cosmos would fail because Cosmos
+// looked up a container by the service name.
+//
+// ResolveDepKey is the compatibility wrapper: given a depends_on key, it
+// returns the container name that key refers to, trying, in order:
+//   1. the key as-is, if a container by that name exists (Cosmos-created)
+//   2. the container whose com.docker.compose.service label == key
+//      (docker-compose-created)
+//   3. the key unchanged (caller surfaces the error)
+//
+// It caches the container list per call, so it is safe to call repeatedly.
+// ---------------------------------------------------------------------------
+
+// listContainersByName returns name (no leading "/") -> container, plus
+// service-name (com.docker.compose.service) -> container, for every container.
+// This is the lookup base for ResolveDepKey. It includes stopped containers so
+// a stopped dependency can still be resolved.
+type containerNameIndex struct {
+	byName    map[string]doctype.ContainerJSON
+	byService map[string]doctype.ContainerJSON
+}
+
+func buildContainerNameIndex() *containerNameIndex {
+	idx := &containerNameIndex{
+		byName:    map[string]doctype.ContainerJSON{},
+		byService: map[string]doctype.ContainerJSON{},
+	}
+
+	containers, err := ListContainers()
+	if err != nil {
+		utils.Debug("buildContainerNameIndex: cannot list containers: " + err.Error())
+		return idx
+	}
+
+	for _, c := range containers {
+		full, err := DockerClient.ContainerInspect(DockerContext, c.ID)
+		if err != nil {
+			continue
+		}
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		} else if full.ContainerJSONBase != nil {
+			name = strings.TrimPrefix(full.Name, "/")
+		}
+		if name != "" {
+			idx.byName[name] = full
+		}
+		if full.Config != nil && full.Config.Labels != nil {
+			if svc := full.Config.Labels["com.docker.compose.service"]; svc != "" {
+				idx.byService[svc] = full
+			}
+		}
+	}
+	return idx
+}
+
+// resolveDepKey maps a depends_on key (service name, as docker-compose stores
+// it) to the container name it refers to, using a prebuilt index. If key is
+// already a container name it is returned unchanged. Falls back to the key
+// itself when unresolvable.
+func resolveDepKey(idx *containerNameIndex, key string) string {
+	if idx == nil {
+		return key
+	}
+	if _, ok := idx.byName[key]; ok {
+		return key
+	}
+	if full, ok := idx.byService[key]; ok {
+		name := ""
+		if full.ContainerJSONBase != nil {
+			name = strings.TrimPrefix(full.Name, "/")
+		}
+		if name != "" {
+			return name
+		}
+	}
+	return key
+}
+
+// ResolveDepKey maps a depends_on key (service name, as docker-compose stores
+// it) to the container name it refers to. If key is already a container name
+// it is returned unchanged. Falls back to the key itself when unresolvable.
+func ResolveDepKey(key string) string {
+	return resolveDepKey(buildContainerNameIndex(), key)
+}
+
+// DependsOnIncludesTarget reports whether deps (a depends_on map keyed by
+// service OR container name) references targetName / targetService. Works for
+// both Cosmos-created stacks (keys = container names) and docker-compose
+// stacks (keys = service names).
+func DependsOnIncludesTarget(deps map[string]dependsOnEntry, targetName, targetService string) (dependsOnEntry, bool) {
+	if entry, ok := deps[targetName]; ok {
+		return entry, true
+	}
+	if targetService != "" && targetService != targetName {
+		if entry, ok := deps[targetService]; ok {
+			return entry, true
+		}
+	}
+	return dependsOnEntry{}, false
 }

--- a/src/docker/depends_on.go
+++ b/src/docker/depends_on.go
@@ -1,0 +1,313 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	doctype "github.com/docker/docker/api/types"
+	conttype "github.com/docker/docker/api/types/container"
+
+	"github.com/azukaar/cosmos-server/src/utils"
+)
+
+// Container dependency conditions, mirroring docker-compose's depends_on
+// condition field. A dependency without an explicit condition is treated as
+// service_started (docker-compose default).
+const (
+	DepConditionStarted          = "service_started"
+	DepConditionHealthy          = "service_healthy"
+	DepConditionCompletedSuccess = "service_completed_successfully"
+
+	// Cosmos-native extension (same semantics as compose, different key so
+	// compose specs keep working unchanged).
+	depConditionRestart = "restart"
+)
+
+// Labels used to persist the dependency graph on the container itself so the
+// runtime restart/recreate paths (which go through EditContainer, not
+// CreateService) can honor depends_on too.
+const (
+	depLabelPrefix = "cosmos.depends_on."
+	depLabelList   = "cosmos.depends_on.list"
+)
+
+// dependencyTimeout is the maximum time we wait for a dependency condition
+// (service_healthy / service_completed_successfully) to be satisfied before
+// giving up. service_started only waits for the container to be running,
+// which is fast.
+const dependencyTimeout = 10 * time.Minute
+
+func depLabelFor(service string) string {
+	return depLabelPrefix + service
+}
+
+// ValidDepCondition reports whether cond is a condition value we understand.
+// Unknown conditions degrade to service_started (compose ignores unknown
+// values for ordering; we do the same but keep the value in labels so the
+// graph is still visible).
+func ValidDepCondition(cond string) bool {
+	switch cond {
+	case DepConditionStarted, DepConditionHealthy, DepConditionCompletedSuccess, depConditionRestart:
+		return true
+	}
+	return false
+}
+
+// NormalizeDepCondition maps an empty/invalid condition to service_started.
+func NormalizeDepCondition(cond string) string {
+	if !ValidDepCondition(cond) {
+		return DepConditionStarted
+	}
+	return cond
+}
+
+// DependsOnFromLabels reconstructs the depends_on map from the labels Cosmos
+// writes at container creation. Returns an empty map when the container has
+// no dependency labels (the common case).
+func DependsOnFromLabels(conf *conttype.Config) map[string]string {
+	deps := map[string]string{}
+	if conf == nil || conf.Labels == nil {
+		return deps
+	}
+
+	list := conf.Labels[depLabelList]
+	if list == "" {
+		return deps
+	}
+
+	for _, service := range strings.Split(list, ",") {
+		service = strings.TrimSpace(service)
+		if service == "" {
+			continue
+		}
+		cond := conf.Labels[depLabelFor(service)]
+		deps[service] = NormalizeDepCondition(cond)
+	}
+	return deps
+}
+
+// SetDependsOnLabels writes the depends_on graph as labels on the container
+// config (mutating conf.Labels). Call this right before ContainerCreate so
+// the graph survives re-creates and can be inspected at runtime.
+func SetDependsOnLabels(conf *conttype.Config, deps map[string]string) {
+	if conf == nil {
+		return
+	}
+	if conf.Labels == nil {
+		conf.Labels = make(map[string]string)
+	}
+
+	keys := make([]string, 0, len(deps))
+	for service := range deps {
+		keys = append(keys, service)
+	}
+	sort.Strings(keys)
+
+	conf.Labels[depLabelList] = strings.Join(keys, ",")
+	for _, service := range keys {
+		conf.Labels[depLabelFor(service)] = NormalizeDepCondition(deps[service])
+	}
+}
+
+// depConditionMet reports whether dep (as currently inspected) satisfies the
+// condition cond. state may be nil for a container that no longer exists.
+func depConditionMet(dep doctype.ContainerJSON, cond string) bool {
+	if cond == "" {
+		cond = DepConditionStarted
+	}
+
+	if dep.ContainerJSONBase == nil || dep.State == nil {
+		return false
+	}
+
+	switch cond {
+	case DepConditionStarted:
+		return dep.State.Running
+	case DepConditionHealthy:
+		if !dep.State.Running {
+			return false
+		}
+		// A container without a healthcheck never becomes "healthy"; treat it
+		// as healthy once it is running (same as compose's service_healthy
+		// behavior for healthcheck-less images).
+		if dep.Config == nil || dep.Config.Healthcheck == nil {
+			return true
+		}
+		return dep.State.Health != nil && dep.State.Health.Status == doctype.Healthy
+	case DepConditionCompletedSuccess:
+		return !dep.State.Running && dep.State.ExitCode == 0
+	default:
+		// Unknown condition: fall back to started.
+		return dep.State.Running
+	}
+}
+
+// WaitForDepCondition polls depName until cond is met, or returns an error
+// after dependencyTimeout. A missing dependency is an error (mirrors compose
+// depending on a service that does not exist).
+func WaitForDepCondition(ctx context.Context, depName string, cond string) error {
+	if cond == "" {
+		cond = DepConditionStarted
+	}
+
+	deadline := time.Now().Add(dependencyTimeout)
+
+	for {
+		dep, err := DockerClient.ContainerInspect(ctx, depName)
+		if err != nil {
+			return fmt.Errorf("depends_on: cannot inspect dependency %q: %w", depName, err)
+		}
+		if depConditionMet(dep, cond) {
+			utils.Debug(fmt.Sprintf("depends_on: %s condition %q met for %s", depName, cond, depName))
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("depends_on: dependency %q did not satisfy condition %q within %s", depName, cond, dependencyTimeout)
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// WaitForDependsOn waits for every dependency of containerName, using the
+// dependency graph persisted on the container's labels. It is used by the
+// runtime paths (restart / recreate / update) that do not go through
+// CreateService's pre-start ordering. Missing dependency containers are
+// considered an error and surfaced.
+func WaitForDependsOn(ctx context.Context, containerName string) error {
+	current, err := DockerClient.ContainerInspect(ctx, containerName)
+	if err != nil {
+		return fmt.Errorf("depends_on: cannot inspect container %q: %w", containerName, err)
+	}
+
+	deps := DependsOnFromLabels(current.Config)
+	if len(deps) == 0 {
+		return nil
+	}
+
+	// Deterministic order (sorted labels) so logs are stable.
+	names := make([]string, 0, len(deps))
+	for name := range deps {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	utils.Log(fmt.Sprintf("depends_on: container %s waiting for %d dependencies: %s",
+		containerName, len(names), strings.Join(names, ", ")))
+
+	for _, depName := range names {
+		cond := deps[depName]
+		utils.Log(fmt.Sprintf("depends_on: waiting for %s (%s)", depName, cond))
+		if err := WaitForDepCondition(ctx, depName, cond); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReorderDependedOn is the boot-up cascade: after containerID starts, any
+// container whose depends_on graph references it (directly or transitively)
+// gets started again in dependency order. Docker knows nothing about
+// depends_on, so without this a dependent that crashed (or never started on
+// boot) would stay down even though its dependency is back.
+//
+// It is deliberately best-effort and non-blocking:
+//   - only containers that are stopped AND depend on containerID are started;
+//     running dependents are left alone (no restarts, no churn)
+//   - failures are logged, never fatal
+//   - runs in its own goroutine (see onDockerStarted)
+func ReorderDependedOn(containerID string) {
+	startedName := ""
+	started, err := DockerClient.ContainerInspect(DockerContext, containerID)
+	if err == nil && started.ContainerJSONBase != nil && started.Name != "" {
+		startedName = started.Name[1:]
+	}
+
+	containers, err := ListContainers()
+	if err != nil {
+		utils.Debug("ReorderDependedOn: cannot list containers: " + err.Error())
+		return
+	}
+
+	// Build a name -> (config, stopped?, running?) map once.
+	byName := map[string]depContainerInfo{}
+	for _, c := range containers {
+		full, err := DockerClient.ContainerInspect(DockerContext, c.ID)
+		if err != nil {
+			continue
+		}
+		name := ""
+		if len(c.Names) > 0 {
+			name = c.Names[0]
+		} else if full.ContainerJSONBase != nil {
+			name = full.Name
+		}
+		if name == "" {
+			continue
+		}
+		byName[name] = depContainerInfo{full: full, name: name}
+	}
+
+	// Find all containers that (transitively) depend on the started one and
+	// are currently stopped.
+	stoppedDependents := []string{}
+	seen := map[string]bool{}
+	var collect func(name string)
+	collect = func(depName string) {
+		for cName, cInfo := range byName {
+			if seen[cName] {
+				continue
+			}
+			deps := DependsOnFromLabels(cInfo.full.Config)
+			if _, ok := deps[depName]; !ok {
+				continue
+			}
+			seen[cName] = true
+			if !cInfo.full.State.Running {
+				stoppedDependents = append(stoppedDependents, cName)
+			}
+			collect(cName[1:]) // transitive
+		}
+	}
+	collect(startedName)
+
+	if len(stoppedDependents) == 0 {
+		utils.Debug("ReorderDependedOn: no stopped dependents for " + startedName)
+		return
+	}
+
+	utils.Log(fmt.Sprintf("ReorderDependedOn: %s started; waking %d stopped dependents", startedName, len(stoppedDependents)))
+
+	// Start them in dependency order, waiting for each one's own deps.
+	ordered := OrderByDependencies(stoppedDependents, depContainerConfigs(byName))
+	for _, name := range ordered {
+		cInfo := byName[name]
+		utils.Log(fmt.Sprintf("ReorderDependedOn: starting %s after %s", name, startedName))
+		if errW := WaitForDependsOn(DockerContext, cInfo.full.ID); errW != nil {
+			utils.Error("ReorderDependedOn: dependency wait failed for "+name, errW)
+			continue
+		}
+		if errS := DockerClient.ContainerStart(DockerContext, cInfo.full.ID, conttype.StartOptions{}); errS != nil {
+			utils.Error("ReorderDependedOn: cannot start "+name, errS)
+		}
+	}
+}
+
+// depContainerInfo carries the few fields ReorderDependedOn needs per container.
+type depContainerInfo struct {
+	full doctype.ContainerJSON
+	name string
+}
+
+// depContainerConfigs adapts map[string]depContainerInfo into the
+// map[string]types.ContainerJSON that OrderByDependencies expects.
+func depContainerConfigs(byName map[string]depContainerInfo) map[string]doctype.ContainerJSON {
+	out := make(map[string]doctype.ContainerJSON, len(byName))
+	for k, v := range byName {
+		out[k] = v.full
+	}
+	return out
+}

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -1,0 +1,154 @@
+package docker
+
+import (
+	"testing"
+
+	doctype "github.com/docker/docker/api/types"
+	conttype "github.com/docker/docker/api/types/container"
+)
+
+func TestSetAndReadDependsOnLabels(t *testing.T) {
+	conf := &conttype.Config{}
+	deps := map[string]string{
+		"db":    "service_healthy",
+		"redis": "service_started",
+	}
+	SetDependsOnLabels(conf, deps)
+
+	got := DependsOnFromLabels(conf)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 deps, got %d: %v", len(got), got)
+	}
+	if got["db"] != "service_healthy" {
+		t.Errorf("db condition = %q, want service_healthy", got["db"])
+	}
+	if got["redis"] != "service_started" {
+		t.Errorf("redis condition = %q, want service_started", got["redis"])
+	}
+}
+
+func TestDependsOnLabelsRoundTripWithEmptyCondition(t *testing.T) {
+	conf := &conttype.Config{}
+	SetDependsOnLabels(conf, map[string]string{
+		"db": "", // compose shorthand (no condition) => service_started
+	})
+	got := DependsOnFromLabels(conf)
+	if got["db"] != "service_started" {
+		t.Errorf("empty condition should normalize to service_started, got %q", got["db"])
+	}
+}
+
+func TestDependsOnFromLabelsNoLabels(t *testing.T) {
+	got := DependsOnFromLabels(&conttype.Config{})
+	if len(got) != 0 {
+		t.Fatalf("expected no deps for label-less config, got %v", got)
+	}
+	got = DependsOnFromLabels(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected no deps for nil config, got %v", got)
+	}
+}
+
+func newTestContainer(state *doctype.ContainerState, conf *conttype.Config) doctype.ContainerJSON {
+	return doctype.ContainerJSON{
+		ContainerJSONBase: &doctype.ContainerJSONBase{State: state},
+		Config:            conf,
+	}
+}
+
+func TestDepConditionMet(t *testing.T) {
+	running := newTestContainer(&doctype.ContainerState{Running: true}, &conttype.Config{})
+	stoppedOK := newTestContainer(&doctype.ContainerState{Running: false, ExitCode: 0}, &conttype.Config{})
+	stoppedFail := newTestContainer(&doctype.ContainerState{Running: false, ExitCode: 1}, &conttype.Config{})
+	noState := doctype.ContainerJSON{}
+
+	if !depConditionMet(running, DepConditionStarted) {
+		t.Error("running should satisfy service_started")
+	}
+	if depConditionMet(stoppedOK, DepConditionStarted) {
+		t.Error("stopped should NOT satisfy service_started")
+	}
+
+	// healthcheck-less running container counts as healthy (compose parity)
+	if !depConditionMet(running, DepConditionHealthy) {
+		t.Error("running healthcheck-less container should satisfy service_healthy")
+	}
+
+	// running with a healthcheck but no health status: not healthy yet
+	hc := newTestContainer(&doctype.ContainerState{Running: true}, &conttype.Config{Healthcheck: &conttype.HealthConfig{Test: []string{"CMD", "true"}}})
+	if depConditionMet(hc, DepConditionHealthy) {
+		t.Error("running with healthcheck but no status should NOT be healthy")
+	}
+	hcHealthy := newTestContainer(&doctype.ContainerState{Running: true, Health: &doctype.Health{Status: doctype.Healthy}}, &conttype.Config{Healthcheck: &conttype.HealthConfig{Test: []string{"CMD", "true"}}})
+	if !depConditionMet(hcHealthy, DepConditionHealthy) {
+		t.Error("healthy container should satisfy service_healthy")
+	}
+
+	if !depConditionMet(stoppedOK, DepConditionCompletedSuccess) {
+		t.Error("exited-0 should satisfy service_completed_successfully")
+	}
+	if depConditionMet(running, DepConditionCompletedSuccess) {
+		t.Error("running should NOT satisfy service_completed_successfully")
+	}
+	if depConditionMet(stoppedFail, DepConditionCompletedSuccess) {
+		t.Error("exited-1 should NOT satisfy service_completed_successfully")
+	}
+	if depConditionMet(noState, DepConditionStarted) {
+		t.Error("nil state should not satisfy any condition")
+	}
+}
+
+func TestOrderByDependencies(t *testing.T) {
+	byName := map[string]doctype.ContainerJSON{
+		"/app":    containerWithDeps("db", "redis"),
+		"/db":     containerWithDeps(""),
+		"/redis":  containerWithDeps(""),
+		"/worker": containerWithDeps("app"),
+	}
+
+	names := []string{"/app", "/db", "/worker", "/redis"}
+	ordered := OrderByDependencies(names, byName)
+
+	// dependencies must appear before dependents
+	pos := map[string]int{}
+	for i, n := range ordered {
+		pos[n] = i
+	}
+	if pos["/db"] > pos["/app"] {
+		t.Errorf("db should start before app; order=%v", ordered)
+	}
+	if pos["/redis"] > pos["/app"] {
+		t.Errorf("redis should start before app; order=%v", ordered)
+	}
+	if pos["/app"] > pos["/worker"] {
+		t.Errorf("app should start before worker; order=%v", ordered)
+	}
+	if len(ordered) != 4 {
+		t.Errorf("expected 4 containers, got %d: %v", len(ordered), ordered)
+	}
+}
+
+func TestOrderByDependenciesCycleFallback(t *testing.T) {
+	byName := map[string]doctype.ContainerJSON{
+		"/a": containerWithDeps("b"),
+		"/b": containerWithDeps("a"),
+	}
+	names := []string{"/a", "/b"}
+	ordered := OrderByDependencies(names, byName)
+	// cycle => keep original order, no infinite loop
+	if len(ordered) != 2 {
+		t.Fatalf("expected 2 containers, got %d: %v", len(ordered), ordered)
+	}
+}
+
+func containerWithDeps(deps ...string) doctype.ContainerJSON {
+	conf := &conttype.Config{Labels: map[string]string{}}
+	if len(deps) > 0 && deps[0] != "" {
+		m := map[string]string{}
+		for _, d := range deps {
+			m[d] = "service_started"
+		}
+		SetDependsOnLabels(conf, m)
+	}
+	return doctype.ContainerJSON{Config: conf}
+}

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -10,8 +10,8 @@ import (
 func TestSetAndReadDependsOnComposeLabel(t *testing.T) {
 	conf := &conttype.Config{}
 	deps := map[string]dependsOnEntry{
-		"db":    {Condition: "service_healthy", Restart: true, Required: true},
-		"redis": {Condition: "service_started", Restart: true, Required: true},
+		"db":    {Condition: "service_healthy", Restart: true},
+		"redis": {Condition: "service_started", Restart: true},
 	}
 	SetDependsOnLabels(conf, deps)
 
@@ -178,7 +178,7 @@ func containerWithDeps(deps ...string) doctype.ContainerJSON {
 	if len(deps) > 0 && deps[0] != "" {
 		m := map[string]dependsOnEntry{}
 		for _, d := range deps {
-			m[d] = dependsOnEntry{Condition: "service_started", Restart: true, Required: true}
+			m[d] = dependsOnEntry{Condition: "service_started", Restart: true}
 		}
 		SetDependsOnLabels(conf, m)
 	}
@@ -286,7 +286,7 @@ func TestDependsOnFieldFromLabelsAndHide(t *testing.T) {
 		composeDependenciesLabel: "db:service_healthy:true,redis:service_started:false",
 		"some.other.label":       "value",
 	}}
-	field := DependsOnFieldFromLabels(conf)
+	field := DependsOnFieldFromLabels(conf, nil)
 	if len(field) != 2 {
 		t.Fatalf("expected 2 field entries, got %d: %v", len(field), field)
 	}
@@ -315,7 +315,7 @@ func TestDependsOnFieldFromLabelsAndHide(t *testing.T) {
 // No label -> empty field, and strip is a no-op that returns the same map.
 func TestDependsOnFieldNoLabel(t *testing.T) {
 	conf := &conttype.Config{Labels: map[string]string{"a": "b"}}
-	if len(DependsOnFieldFromLabels(conf)) != 0 {
+	if len(DependsOnFieldFromLabels(conf, nil)) != 0 {
 		t.Fatal("no label should mean no depends_on field")
 	}
 	labels := stripInternalDependsOnLabel(conf.Labels)

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -7,34 +7,60 @@ import (
 	conttype "github.com/docker/docker/api/types/container"
 )
 
-func TestSetAndReadDependsOnLabels(t *testing.T) {
+func TestSetAndReadDependsOnComposeLabel(t *testing.T) {
 	conf := &conttype.Config{}
-	deps := map[string]string{
-		"db":    "service_healthy",
-		"redis": "service_started",
+	deps := map[string]dependsOnEntry{
+		"db":    {Condition: "service_healthy", Restart: true, Required: true},
+		"redis": {Condition: "service_started", Restart: true, Required: true},
 	}
 	SetDependsOnLabels(conf, deps)
+
+	// Must be written in docker-compose's own label + format.
+	if conf.Labels[composeDependenciesLabel] == "" {
+		t.Fatal("compose depends_on label not written")
+	}
+	if _, ok := conf.Labels["cosmos.depends_on.db"]; ok {
+		t.Fatal("should NOT write custom cosmos.depends_on.* labels anymore")
+	}
 
 	got := DependsOnFromLabels(conf)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 deps, got %d: %v", len(got), got)
 	}
-	if got["db"] != "service_healthy" {
-		t.Errorf("db condition = %q, want service_healthy", got["db"])
+	if got["db"].Condition != "service_healthy" {
+		t.Errorf("db condition = %q, want service_healthy", got["db"].Condition)
 	}
-	if got["redis"] != "service_started" {
-		t.Errorf("redis condition = %q, want service_started", got["redis"])
+	if got["redis"].Condition != "service_started" {
+		t.Errorf("redis condition = %q, want service_started", got["redis"].Condition)
+	}
+	if !got["db"].Restart {
+		t.Error("db restart should be true")
 	}
 }
 
-func TestDependsOnLabelsRoundTripWithEmptyCondition(t *testing.T) {
-	conf := &conttype.Config{}
-	SetDependsOnLabels(conf, map[string]string{
-		"db": "", // compose shorthand (no condition) => service_started
-	})
+// A label written by real docker-compose (com.docker.compose.depends_on,
+// "dep:condition:restart" format) must parse correctly.
+func TestParseComposeLabel(t *testing.T) {
+	conf := &conttype.Config{Labels: map[string]string{
+		composeDependenciesLabel: "db:service_healthy:true,redis:service_started:false,worker:service_completed_successfully:true",
+	}}
 	got := DependsOnFromLabels(conf)
-	if got["db"] != "service_started" {
-		t.Errorf("empty condition should normalize to service_started, got %q", got["db"])
+	if len(got) != 3 {
+		t.Fatalf("expected 3 deps, got %d: %v", len(got), got)
+	}
+	if got["db"].Condition != "service_healthy" || !got["db"].Restart {
+		t.Errorf("db = %+v", got["db"])
+	}
+	if got["redis"].Condition != "service_started" || got["redis"].Restart {
+		t.Errorf("redis = %+v", got["redis"])
+	}
+	// legacy fragment without condition -> running_or_healthy (compose parity)
+	conf2 := &conttype.Config{Labels: map[string]string{
+		composeDependenciesLabel: "db:service_healthy:true,cache",
+	}}
+	got2 := DependsOnFromLabels(conf2)
+	if got2["cache"].Condition != "running_or_healthy" {
+		t.Errorf("legacy no-condition dep should default to running_or_healthy, got %q", got2["cache"].Condition)
 	}
 }
 
@@ -69,9 +95,15 @@ func TestDepConditionMet(t *testing.T) {
 		t.Error("stopped should NOT satisfy service_started")
 	}
 
-	// healthcheck-less running container counts as healthy (compose parity)
-	if !depConditionMet(running, DepConditionHealthy) {
-		t.Error("running healthcheck-less container should satisfy service_healthy")
+	// healthcheck-less running container counts as healthy for
+	// running_or_healthy (compose parity: fallback to running)
+	if !depConditionMet(running, DepConditionRunningOrHealthy) {
+		t.Error("running healthcheck-less container should satisfy running_or_healthy")
+	}
+
+	// service_healthy with NO healthcheck: compose errors / treats as unmet
+	if depConditionMet(running, DepConditionHealthy) {
+		t.Error("running healthcheck-less container should NOT satisfy service_healthy")
 	}
 
 	// running with a healthcheck but no health status: not healthy yet
@@ -144,11 +176,105 @@ func TestOrderByDependenciesCycleFallback(t *testing.T) {
 func containerWithDeps(deps ...string) doctype.ContainerJSON {
 	conf := &conttype.Config{Labels: map[string]string{}}
 	if len(deps) > 0 && deps[0] != "" {
-		m := map[string]string{}
+		m := map[string]dependsOnEntry{}
 		for _, d := range deps {
-			m[d] = "service_started"
+			m[d] = dependsOnEntry{Condition: "service_started", Restart: true, Required: true}
 		}
 		SetDependsOnLabels(conf, m)
 	}
 	return doctype.ContainerJSON{Config: conf}
+}
+
+// Regression test for the pihole/tailscale failure: a service with
+// network_mode: container:tailscale (external target, not in the batch) must
+// NOT be treated as an unsatisfied dependency.
+func TestReOrderServicesExternalNetworkMode(t *testing.T) {
+	serviceMap := map[string]ContainerCreateRequestContainer{
+		"pihole": {
+			Name:        "pihole",
+			NetworkMode: "container:tailscale",
+		},
+	}
+	order, _, err := ReOrderServices(serviceMap)
+	if err != nil {
+		t.Fatalf("external network_mode target should not error, got: %v", err)
+	}
+	if len(order) != 1 || order[0].Name != "pihole" {
+		t.Fatalf("expected pihole in start order, got %+v", order)
+	}
+}
+
+// A service with network_mode referencing an in-batch service must be ordered
+// after it (soft constraint), and should not fail.
+func TestReOrderServicesInBatchNetworkMode(t *testing.T) {
+	serviceMap := map[string]ContainerCreateRequestContainer{
+		"app": {
+			Name:        "app",
+			NetworkMode: "container:db",
+		},
+		"db": {
+			Name: "db",
+		},
+	}
+	order, _, err := ReOrderServices(serviceMap)
+	if err != nil {
+		t.Fatalf("in-batch network_mode should not error, got: %v", err)
+	}
+	if len(order) != 2 {
+		t.Fatalf("expected 2 in order, got %d: %+v", len(order), order)
+	}
+	// db must start before app
+	pos := map[string]int{}
+	for i, c := range order {
+		pos[c.Name] = i
+	}
+	if pos["db"] > pos["app"] {
+		t.Fatalf("db should start before app; order=%v", order)
+	}
+}
+
+// Depends_on must still be respected as a hard ordering constraint.
+func TestReOrderServicesDependsOn(t *testing.T) {
+	serviceMap := map[string]ContainerCreateRequestContainer{
+		"app": {
+			Name: "app",
+			DependsOn: map[string]ContainerCreateRequestContainerDependsOnCont{
+				"db": {Condition: "service_started"},
+			},
+		},
+		"db": {Name: "db"},
+	}
+	order, _, err := ReOrderServices(serviceMap)
+	if err != nil {
+		t.Fatalf("depends_on should not error, got: %v", err)
+	}
+	pos := map[string]int{}
+	for i, c := range order {
+		pos[c.Name] = i
+	}
+	if pos["db"] > pos["app"] {
+		t.Fatalf("db should start before app via depends_on; order=%v", order)
+	}
+}
+
+// Circular depends_on must still error.
+func TestReOrderServicesCircular(t *testing.T) {
+	serviceMap := map[string]ContainerCreateRequestContainer{
+		"a": {
+			Name: "a",
+			DependsOn: map[string]ContainerCreateRequestContainerDependsOnCont{
+				"b": {Condition: "service_started"},
+			},
+		},
+		"b": {
+			Name: "b",
+			DependsOn: map[string]ContainerCreateRequestContainerDependsOnCont{
+				"a": {Condition: "service_started"},
+			},
+		},
+	}
+	_, _, err := ReOrderServices(serviceMap)
+	if err == nil {
+		t.Fatal("circular depends_on should error")
+	}
 }

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -329,11 +329,10 @@ func TestContainerStackVariants(t *testing.T) {
 		labels map[string]string
 		want   string
 	}{
-		{map[string]string{"cosmos-stack": "mystack"}, "mystack"},
 		{map[string]string{"cosmos.stack": "mystack"}, "mystack"},
 		{map[string]string{"com.docker.compose.project": "proj"}, "proj"},
 		{map[string]string{"com.docker.compose.project": "proj", "cosmos.stack": "other"}, "other"}, // cosmos wins priority
-		{map[string]string{"cosmos-stack-main": "true"}, ""},                                        // main marker alone -> no name
+		{map[string]string{"cosmos.stack.main": "true"}, ""},                                      // main marker alone -> no name
 		{nil, ""},
 	}
 	for i, c := range cases {

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -329,6 +329,7 @@ func TestContainerStackVariants(t *testing.T) {
 		labels map[string]string
 		want   string
 	}{
+		{map[string]string{"cosmos-stack": "dashstack"}, "dashstack"},
 		{map[string]string{"cosmos.stack": "mystack"}, "mystack"},
 		{map[string]string{"com.docker.compose.project": "proj"}, "proj"},
 		{map[string]string{"com.docker.compose.project": "proj", "cosmos.stack": "other"}, "other"}, // cosmos wins priority

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -278,3 +278,48 @@ func TestReOrderServicesCircular(t *testing.T) {
 		t.Fatal("circular depends_on should error")
 	}
 }
+
+// The depends_on *field* must be reconstructed from the label, and the label
+// itself hidden, so the source of truth the user sees/edits is the field.
+func TestDependsOnFieldFromLabelsAndHide(t *testing.T) {
+	conf := &conttype.Config{Labels: map[string]string{
+		composeDependenciesLabel: "db:service_healthy:true,redis:service_started:false",
+		"some.other.label":       "value",
+	}}
+	field := DependsOnFieldFromLabels(conf)
+	if len(field) != 2 {
+		t.Fatalf("expected 2 field entries, got %d: %v", len(field), field)
+	}
+	if field["db"].Condition != "service_healthy" || field["db"].Restart != "true" {
+		t.Errorf("db = %+v", field["db"])
+	}
+	if field["redis"].Condition != "service_started" || field["redis"].Restart != "false" {
+		t.Errorf("redis = %+v", field["redis"])
+	}
+
+	// The internal label must be hidden; other labels kept.
+	labels := stripInternalDependsOnLabel(conf.Labels)
+	if _, ok := labels[composeDependenciesLabel]; ok {
+		t.Fatal("com.docker.compose.depends_on label should be hidden")
+	}
+	if labels["some.other.label"] != "value" {
+		t.Errorf("other labels should be preserved, got %v", labels)
+	}
+
+	// Original labels map must not be mutated.
+	if _, ok := conf.Labels[composeDependenciesLabel]; !ok {
+		t.Fatal("original labels map should not be mutated")
+	}
+}
+
+// No label -> empty field, and strip is a no-op that returns the same map.
+func TestDependsOnFieldNoLabel(t *testing.T) {
+	conf := &conttype.Config{Labels: map[string]string{"a": "b"}}
+	if len(DependsOnFieldFromLabels(conf)) != 0 {
+		t.Fatal("no label should mean no depends_on field")
+	}
+	labels := stripInternalDependsOnLabel(conf.Labels)
+	if labels["a"] != "b" {
+		t.Fatalf("labels should be unchanged: %v", labels)
+	}
+}

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -323,3 +323,45 @@ func TestDependsOnFieldNoLabel(t *testing.T) {
 		t.Fatalf("labels should be unchanged: %v", labels)
 	}
 }
+
+func TestContainerStackVariants(t *testing.T) {
+	cases := []struct {
+		labels map[string]string
+		want   string
+	}{
+		{map[string]string{"cosmos-stack": "mystack"}, "mystack"},
+		{map[string]string{"cosmos.stack": "mystack"}, "mystack"},
+		{map[string]string{"com.docker.compose.project": "proj"}, "proj"},
+		{map[string]string{"com.docker.compose.project": "proj", "cosmos.stack": "other"}, "other"}, // cosmos wins priority
+		{map[string]string{"cosmos-stack-main": "true"}, ""},                                        // main marker alone -> no name
+		{nil, ""},
+	}
+	for i, c := range cases {
+		conf := &conttype.Config{Labels: c.labels}
+		if got := ContainerStack(conf); got != c.want {
+			t.Errorf("case %d: ContainerStack = %q, want %q", i, got, c.want)
+		}
+	}
+}
+
+func TestRestartDependentsNeeded(t *testing.T) {
+	// depends_on restart:true -> restart
+	if !restartDependentsNeeded(dependsOnEntry{Restart: true}, "") {
+		t.Error("depends_on restart:true should restart dependent")
+	}
+	// depends_on restart:false -> no restart
+	if restartDependentsNeeded(dependsOnEntry{Restart: false}, "") {
+		t.Error("depends_on restart:false should NOT restart dependent")
+	}
+	// network_mode container: (even restart:false) -> restart (namespace shared)
+	if !restartDependentsNeeded(dependsOnEntry{Restart: false}, "container:db") {
+		t.Error("network_mode container: should restart dependent even with restart:false")
+	}
+	if !restartDependentsNeeded(dependsOnEntry{Restart: false}, "service:db") {
+		t.Error("network_mode service: should restart dependent even with restart:false")
+	}
+	// plain depends_on no restart -> default false -> no restart
+	if restartDependentsNeeded(dependsOnEntry{}, "bridge") {
+		t.Error("default depends_on (restart false) should NOT restart")
+	}
+}

--- a/src/docker/depends_on_test.go
+++ b/src/docker/depends_on_test.go
@@ -332,7 +332,7 @@ func TestContainerStackVariants(t *testing.T) {
 		{map[string]string{"cosmos.stack": "mystack"}, "mystack"},
 		{map[string]string{"com.docker.compose.project": "proj"}, "proj"},
 		{map[string]string{"com.docker.compose.project": "proj", "cosmos.stack": "other"}, "other"}, // cosmos wins priority
-		{map[string]string{"cosmos.stack.main": "true"}, ""},                                      // main marker alone -> no name
+		{map[string]string{"cosmos.stack.main": "true"}, ""},                                        // main marker alone -> no name
 		{nil, ""},
 	}
 	for i, c := range cases {
@@ -362,5 +362,64 @@ func TestRestartDependentsNeeded(t *testing.T) {
 	// plain depends_on no restart -> default false -> no restart
 	if restartDependentsNeeded(dependsOnEntry{}, "bridge") {
 		t.Error("default depends_on (restart false) should NOT restart")
+	}
+}
+
+// Service-name <-> container-name resolution (docker-compose compatibility).
+func TestResolveDepKey(t *testing.T) {
+	mk := func(name, svc string) doctype.ContainerJSON {
+		full := doctype.ContainerJSON{
+			ContainerJSONBase: &doctype.ContainerJSONBase{Name: "/" + name},
+			Config:            &conttype.Config{Labels: map[string]string{}},
+		}
+		if svc != "" {
+			full.Config.Labels["com.docker.compose.service"] = svc
+		}
+		return full
+	}
+
+	idx := &containerNameIndex{byName: map[string]doctype.ContainerJSON{}, byService: map[string]doctype.ContainerJSON{}}
+	idx.byName["my-db"] = mk("my-db", "db")
+	idx.byName["my-web"] = mk("my-web", "web")
+	idx.byService["db"] = idx.byName["my-db"]
+	idx.byService["web"] = idx.byName["my-web"]
+
+	// Cosmos-style key (container name) -> unchanged
+	if got := resolveDepKey(idx, "my-db"); got != "my-db" {
+		t.Errorf("container-name key: got %q want my-db", got)
+	}
+	// docker-compose-style key (service name) -> resolved to container name
+	if got := resolveDepKey(idx, "db"); got != "my-db" {
+		t.Errorf("service-name key db: got %q want my-db", got)
+	}
+	if got := resolveDepKey(idx, "web"); got != "my-web" {
+		t.Errorf("service-name key web: got %q want my-web", got)
+	}
+	// unresolvable -> unchanged
+	if got := resolveDepKey(idx, "missing"); got != "missing" {
+		t.Errorf("missing key: got %q want missing", got)
+	}
+	// nil index -> unchanged
+	if got := resolveDepKey(nil, "db"); got != "db" {
+		t.Errorf("nil index: got %q want db", got)
+	}
+}
+
+func TestDependsOnIncludesTarget(t *testing.T) {
+	deps := map[string]dependsOnEntry{
+		"db":    {Condition: "service_healthy", Restart: true},
+		"my-db": {Condition: "service_started", Restart: true},
+	}
+	// container-name match
+	if _, ok := DependsOnIncludesTarget(deps, "my-db", "db"); !ok {
+		t.Error("should match by container name my-db")
+	}
+	// service-name match
+	if entry, ok := DependsOnIncludesTarget(deps, "custom-db", "db"); !ok || entry.Condition != "service_healthy" {
+		t.Errorf("should match by service name db, got %+v ok=%v", entry, ok)
+	}
+	// no match
+	if _, ok := DependsOnIncludesTarget(deps, "web", "web"); ok {
+		t.Error("should not match web")
 	}
 }

--- a/src/docker/docker.go
+++ b/src/docker/docker.go
@@ -446,8 +446,15 @@ func RecreateDepedencies(containerID, containerName string) {
 
 		byName[container.Names[0]] = fullContainer
 
+		// targetService lets we match depends_on keys that docker-compose stored
+		// by SERVICE name (in addition to Cosmos's container-name keys).
+		targetService := ""
+		if target.Config != nil && target.Config.Labels != nil {
+			targetService = target.Config.Labels["com.docker.compose.service"]
+		}
+
 		depends := DependsOnFromLabels(fullContainer.Config)
-		if depEntry, hasDepLabel := depends[containerName[1:]]; hasDepLabel {
+		if depEntry, hasDepLabel := DependsOnIncludesTarget(depends, containerName[1:], targetService); hasDepLabel {
 			if depEntry.Restart || NetworkModeContainerRef(string(fullContainer.HostConfig.NetworkMode)) || NetworkModeServiceRef(string(fullContainer.HostConfig.NetworkMode)) {
 				utils.Log("RecreateDepedencies - depends_on: " + container.Names[0] + " depends on " + containerName[1:] + " (restart=" + strconv.FormatBool(depEntry.Restart) + ") -> recreating")
 				dependentNames = append(dependentNames, container.Names[0])
@@ -519,6 +526,18 @@ func OrderByDependencies(names []string, byName map[string]types.ContainerJSON) 
 	remaining := make([]string, len(names))
 	copy(remaining, names)
 
+	// Index container names -> container so a depends_on key stored by SERVICE
+	// name (docker-compose) can be matched against the container names in this
+	// batch (Cosmos keys are container names already).
+	serviceToName := map[string]string{}
+	for name, full := range byName {
+		if full.Config != nil && full.Config.Labels != nil {
+			if svc := full.Config.Labels["com.docker.compose.service"]; svc != "" {
+				serviceToName[svc] = strings.TrimPrefix(name, "/")
+			}
+		}
+	}
+
 	for len(remaining) > 0 {
 		changed := false
 		next := []string{}
@@ -527,7 +546,11 @@ func OrderByDependencies(names []string, byName map[string]types.ContainerJSON) 
 			deps := DependsOnFromLabels(full.Config)
 			ready := true
 			for dep := range deps {
+				// resolve service-name key to container name (fallback: dep)
 				depName := "/" + dep
+				if resolved, ok := serviceToName[dep]; ok {
+					depName = "/" + resolved
+				}
 				// only wait for deps that are part of this recreate batch
 				for _, r := range remaining {
 					if r == depName {

--- a/src/docker/docker.go
+++ b/src/docker/docker.go
@@ -219,6 +219,15 @@ func EditContainer(oldContainerID string, newConfig types.ContainerJSON, noLock 
 			return "", err
 		}
 
+		// Carry the depends_on graph across re-creates. The labels are the only
+		// durable record of it (compose defines it at the service level, Docker
+		// has no native depends_on), so if we drop them here a recreated
+		// container loses its dependency ordering at runtime.
+		dependsOn := DependsOnFromLabels(oldContainer.Config)
+		if len(dependsOn) > 0 && newConfig.Config != nil {
+			SetDependsOnLabels(newConfig.Config, dependsOn)
+		}
+
 		// check if new image exists, if not, pull it
 		_, _, errImage := DockerClient.ImageInspectWithRaw(DockerContext, newConfig.Config.Image)
 		if errImage != nil {
@@ -395,6 +404,16 @@ func RecreateDepedencies(containerID, containerName string) {
 		return
 	}
 
+	// Collect every container that directly depends on the recreated one,
+	// either through network_mode (container:/service:) or through the
+	// depends_on labels Cosmos persists at create time.
+	//
+	// Recreating a dependency under compose semantics means the dependent must
+	// be re-created too (its network endpoints/aliases to the old container
+	// are gone), then started again in dependency order.
+	dependentNames := []string{}
+	byName := map[string]types.ContainerJSON{}
+
 	for _, container := range containers {
 		if container.ID == containerID {
 			continue
@@ -406,13 +425,20 @@ func RecreateDepedencies(containerID, containerName string) {
 			continue
 		}
 
+		byName[container.Names[0]] = fullContainer
+
+		depends := DependsOnFromLabels(fullContainer.Config)
+		_, hasDepLabel := depends[containerName[1:]]
+		if hasDepLabel {
+			utils.Log("RecreateDepedencies - depends_on: " + container.Names[0] + " depends on " + containerName[1:])
+			dependentNames = append(dependentNames, container.Names[0])
+			continue
+		}
+
 		// check if network mode contains containerID
 		if strings.Contains(string(fullContainer.HostConfig.NetworkMode), containerID) {
 			utils.Log("RecreateDepedencies - Recreating " + container.Names[0])
-			_, err := EditContainer(container.ID, fullContainer, true)
-			if err != nil {
-				utils.Error("RecreateDepedencies - Failed to update - ", err)
-			}
+			dependentNames = append(dependentNames, container.Names[0])
 			continue
 		}
 
@@ -423,12 +449,90 @@ func RecreateDepedencies(containerID, containerName string) {
 		labelTarget := NetworkModeRefTarget(labelMode)
 		if labelTarget != "" && (labelTarget == containerName[1:] || labelTarget == containerID) {
 			utils.Log("RecreateDepedencies - Recreating " + container.Names[0])
-			_, err := EditContainer(container.ID, fullContainer, true)
-			if err != nil {
-				utils.Error("RecreateDepedencies - Failed to update - ", err)
-			}
+			dependentNames = append(dependentNames, container.Names[0])
 		}
 	}
+
+	if len(dependentNames) == 0 {
+		return
+	}
+
+	// Recreate dependents in dependency order (dependencies first), then start
+	// them in the same order, waiting for each one's own dependencies.
+	orderedNames := OrderByDependencies(dependentNames, byName)
+
+	for _, name := range orderedNames {
+		fullContainer := byName[name]
+		if fullContainer.ID == "" {
+			continue
+		}
+		utils.Log("RecreateDepedencies - Recreating " + name)
+		_, err := EditContainer(fullContainer.ID, fullContainer, true)
+		if err != nil {
+			utils.Error("RecreateDepedencies - Failed to update - ", err)
+			continue
+		}
+
+		utils.Log("RecreateDepedencies - Starting " + name)
+		errStart := DockerClient.ContainerStart(DockerContext, fullContainer.ID, conttype.StartOptions{})
+		if errStart != nil {
+			utils.Error("RecreateDepedencies - Failed to start - ", errStart)
+		} else if errW := WaitForDependsOn(DockerContext, fullContainer.ID); errW != nil {
+			utils.Error("RecreateDepedencies - Dependency wait failed for "+name, errW)
+		}
+	}
+}
+
+// OrderByDependencies topologically sorts names (dependencies before
+// dependents) based solely on the persisted labels. Containers whose
+// dependency is not in names (already satisfied, or external) are left in
+// place; cycles are broken by keeping the original order. This is a small,
+// iterate-until-stable ordering, fine for realistic compose stacks.
+func OrderByDependencies(names []string, byName map[string]types.ContainerJSON) []string {
+	if len(names) < 2 {
+		return names
+	}
+
+	ordered := make([]string, 0, len(names))
+	remaining := make([]string, len(names))
+	copy(remaining, names)
+
+	for len(remaining) > 0 {
+		changed := false
+		next := []string{}
+		for _, name := range remaining {
+			full := byName[name]
+			deps := DependsOnFromLabels(full.Config)
+			ready := true
+			for dep := range deps {
+				depName := "/" + dep
+				// only wait for deps that are part of this recreate batch
+				for _, r := range remaining {
+					if r == depName {
+						ready = false
+						break
+					}
+				}
+				if !ready {
+					break
+				}
+			}
+			if ready {
+				ordered = append(ordered, name)
+				changed = true
+			} else {
+				next = append(next, name)
+			}
+		}
+		remaining = next
+		if !changed {
+			// cycle / unresolvable: take the rest as-is
+			ordered = append(ordered, remaining...)
+			break
+		}
+	}
+
+	return ordered
 }
 
 func ListContainers() ([]types.Container, error) {

--- a/src/docker/docker.go
+++ b/src/docker/docker.go
@@ -398,21 +398,9 @@ func EditContainer(oldContainerID string, newConfig types.ContainerJSON, noLock 
 }
 
 func RecreateDepedencies(containerID, containerName string) {
-	containers, err := ListContainers()
-	if err != nil {
-		utils.Error("RecreateDepedencies", err)
-		return
-	}
-
-	// Recreating one container invalidates the container: references of its
-	// stack siblings, so those siblings must be re-created too, then started
-	// in dependency order. Mirror docker-compose restart semantics:
-	//   - network_mode/ipc/pid namespace sharers always re-create (the shared
-	//     namespace died with the old container)
-	//   - depends_on dependents re-create only when restart:true
-	// The cascade is scoped to the SAME stack (com.docker.compose.project /
-	// cosmos.stack) so unrelated containers that happen to reference this one
-	// are not touched.
+	// Recreating a container invalidates its stack siblings' references
+	// (network_mode namespace and depends_on restart:true), so recreate them in
+	// dependency order. Scoped to the same stack.
 
 	target, err := DockerClient.ContainerInspect(DockerContext, containerID)
 	if err != nil {
@@ -425,49 +413,32 @@ func RecreateDepedencies(containerID, containerName string) {
 		return
 	}
 
+	targetService := ""
+	if target.Config != nil && target.Config.Labels != nil {
+		targetService = target.Config.Labels["com.docker.compose.service"]
+	}
+
+	index := buildSameStackIndex(targetStack, containerID)
+	byName := depContainerConfigs(index)
+
 	dependentNames := []string{}
-	byName := map[string]types.ContainerJSON{}
-
-	for _, container := range containers {
-		if container.ID == containerID {
-			continue
-		}
-
-		fullContainer, err := DockerClient.ContainerInspect(DockerContext, container.ID)
-		if err != nil {
-			utils.Error("RecreateDepedencies", err)
-			continue
-		}
-
-		// scope to same stack
-		if ContainerStack(fullContainer.Config) != targetStack {
-			continue
-		}
-
-		byName[container.Names[0]] = fullContainer
-
-		// targetService lets we match depends_on keys that docker-compose stored
-		// by SERVICE name (in addition to Cosmos's container-name keys).
-		targetService := ""
-		if target.Config != nil && target.Config.Labels != nil {
-			targetService = target.Config.Labels["com.docker.compose.service"]
-		}
-
+	for name, fullContainer := range byName {
+		// docker-compose stores depends_on keys by service name
 		depends := DependsOnFromLabels(fullContainer.Config)
 		if depEntry, hasDepLabel := DependsOnIncludesTarget(depends, containerName[1:], targetService); hasDepLabel {
 			if depEntry.Restart || NetworkModeContainerRef(string(fullContainer.HostConfig.NetworkMode)) || NetworkModeServiceRef(string(fullContainer.HostConfig.NetworkMode)) {
-				utils.Log("RecreateDepedencies - depends_on: " + container.Names[0] + " depends on " + containerName[1:] + " (restart=" + strconv.FormatBool(depEntry.Restart) + ") -> recreating")
-				dependentNames = append(dependentNames, container.Names[0])
+				utils.Log("RecreateDepedencies - depends_on: " + name + " depends on " + containerName[1:] + " (restart=" + strconv.FormatBool(depEntry.Restart) + ") -> recreating")
+				dependentNames = append(dependentNames, name)
 			} else {
-				utils.Debug("RecreateDepedencies - depends_on: " + container.Names[0] + " depends on " + containerName[1:] + " (restart=false) -> skipping")
+				utils.Debug("RecreateDepedencies - depends_on: " + name + " depends on " + containerName[1:] + " (restart=false) -> skipping")
 			}
 			continue
 		}
 
 		// check if network mode contains containerID
 		if strings.Contains(string(fullContainer.HostConfig.NetworkMode), containerID) {
-			utils.Log("RecreateDepedencies - Recreating " + container.Names[0])
-			dependentNames = append(dependentNames, container.Names[0])
+			utils.Log("RecreateDepedencies - Recreating " + name)
+			dependentNames = append(dependentNames, name)
 			continue
 		}
 
@@ -477,8 +448,8 @@ func RecreateDepedencies(containerID, containerName string) {
 		labelMode := GetLabel(fullContainer, "cosmos-force-network-mode")
 		labelTarget := NetworkModeRefTarget(labelMode)
 		if labelTarget != "" && (labelTarget == containerName[1:] || labelTarget == containerID) {
-			utils.Log("RecreateDepedencies - Recreating " + container.Names[0])
-			dependentNames = append(dependentNames, container.Names[0])
+			utils.Log("RecreateDepedencies - Recreating " + name)
+			dependentNames = append(dependentNames, name)
 		}
 	}
 
@@ -512,11 +483,8 @@ func RecreateDepedencies(containerID, containerName string) {
 	}
 }
 
-// OrderByDependencies topologically sorts names (dependencies before
-// dependents) based solely on the persisted labels. Containers whose
-// dependency is not in names (already satisfied, or external) are left in
-// place; cycles are broken by keeping the original order. This is a small,
-// iterate-until-stable ordering, fine for realistic compose stacks.
+// OrderByDependencies topologically sorts names (dependencies first) from the
+// persisted depends_on labels; unresolvable cycles keep the original order.
 func OrderByDependencies(names []string, byName map[string]types.ContainerJSON) []string {
 	if len(names) < 2 {
 		return names
@@ -526,9 +494,7 @@ func OrderByDependencies(names []string, byName map[string]types.ContainerJSON) 
 	remaining := make([]string, len(names))
 	copy(remaining, names)
 
-	// Index container names -> container so a depends_on key stored by SERVICE
-	// name (docker-compose) can be matched against the container names in this
-	// batch (Cosmos keys are container names already).
+	// map compose service names to container names for service-keyed deps
 	serviceToName := map[string]string{}
 	for name, full := range byName {
 		if full.Config != nil && full.Config.Labels != nil {

--- a/src/docker/docker.go
+++ b/src/docker/docker.go
@@ -411,8 +411,8 @@ func RecreateDepedencies(containerID, containerName string) {
 	//     namespace died with the old container)
 	//   - depends_on dependents re-create only when restart:true
 	// The cascade is scoped to the SAME stack (com.docker.compose.project /
-	// cosmos.stack / cosmos-stack) so unrelated containers that happen to
-	// reference this one are not touched.
+	// cosmos.stack) so unrelated containers that happen to reference this one
+	// are not touched.
 
 	target, err := DockerClient.ContainerInspect(DockerContext, containerID)
 	if err != nil {

--- a/src/docker/docker.go
+++ b/src/docker/docker.go
@@ -404,13 +404,27 @@ func RecreateDepedencies(containerID, containerName string) {
 		return
 	}
 
-	// Collect every container that directly depends on the recreated one,
-	// either through network_mode (container:/service:) or through the
-	// depends_on labels Cosmos persists at create time.
-	//
-	// Recreating a dependency under compose semantics means the dependent must
-	// be re-created too (its network endpoints/aliases to the old container
-	// are gone), then started again in dependency order.
+	// Recreating one container invalidates the container: references of its
+	// stack siblings, so those siblings must be re-created too, then started
+	// in dependency order. Mirror docker-compose restart semantics:
+	//   - network_mode/ipc/pid namespace sharers always re-create (the shared
+	//     namespace died with the old container)
+	//   - depends_on dependents re-create only when restart:true
+	// The cascade is scoped to the SAME stack (com.docker.compose.project /
+	// cosmos.stack / cosmos-stack) so unrelated containers that happen to
+	// reference this one are not touched.
+
+	target, err := DockerClient.ContainerInspect(DockerContext, containerID)
+	if err != nil {
+		utils.Error("RecreateDepedencies: cannot inspect target", err)
+		return
+	}
+	targetStack := ContainerStack(target.Config)
+	if targetStack == "" {
+		utils.Debug("RecreateDepedencies: " + containerName + " not part of a stack; no cascade")
+		return
+	}
+
 	dependentNames := []string{}
 	byName := map[string]types.ContainerJSON{}
 
@@ -425,13 +439,21 @@ func RecreateDepedencies(containerID, containerName string) {
 			continue
 		}
 
+		// scope to same stack
+		if ContainerStack(fullContainer.Config) != targetStack {
+			continue
+		}
+
 		byName[container.Names[0]] = fullContainer
 
 		depends := DependsOnFromLabels(fullContainer.Config)
-		_, hasDepLabel := depends[containerName[1:]]
-		if hasDepLabel {
-			utils.Log("RecreateDepedencies - depends_on: " + container.Names[0] + " depends on " + containerName[1:])
-			dependentNames = append(dependentNames, container.Names[0])
+		if depEntry, hasDepLabel := depends[containerName[1:]]; hasDepLabel {
+			if depEntry.Restart || NetworkModeContainerRef(string(fullContainer.HostConfig.NetworkMode)) || NetworkModeServiceRef(string(fullContainer.HostConfig.NetworkMode)) {
+				utils.Log("RecreateDepedencies - depends_on: " + container.Names[0] + " depends on " + containerName[1:] + " (restart=" + strconv.FormatBool(depEntry.Restart) + ") -> recreating")
+				dependentNames = append(dependentNames, container.Names[0])
+			} else {
+				utils.Debug("RecreateDepedencies - depends_on: " + container.Names[0] + " depends on " + containerName[1:] + " (restart=false) -> skipping")
+			}
 			continue
 		}
 

--- a/src/docker/docker.go
+++ b/src/docker/docker.go
@@ -136,13 +136,26 @@ func EditContainer(oldContainerID string, newConfig types.ContainerJSON, noLock 
 		}
 	}
 
-	if !HasLabel(newConfig, "cosmos-force-network-mode") {
-		if (strings.HasPrefix(string(newConfig.HostConfig.NetworkMode), "service:") ||
-			strings.HasPrefix(string(newConfig.HostConfig.NetworkMode), "container:")) {
-				AddLabels(newConfig, map[string]string{"cosmos-force-network-mode": string(newConfig.HostConfig.NetworkMode)})
+	// Normalize container/service network-mode references to stable container
+	// names BEFORE persisting anything. Docker accepts both names and IDs in
+	// "container:<ref>" but an ID goes stale when the referenced container is
+	// recreated, breaking the network sharing. The name is stable across
+	// recreations, so resolve any ID (or compose "service:" alias) to
+	// container:<name> here and keep the cosmos-force-network-mode label in
+	// sync — this is the single choke point every recreate/update path flows
+	// through, and it self-heals references that were previously stored as IDs.
+	labelNetworkMode := ""
+	if GetLabel(newConfig, "cosmos-force-network-mode") != "" {
+		labelNetworkMode = ContainerRefToName(GetLabel(newConfig, "cosmos-force-network-mode"))
+		newConfig.HostConfig.NetworkMode = container.NetworkMode(labelNetworkMode)
+		AddLabels(newConfig, map[string]string{"cosmos-force-network-mode": labelNetworkMode})
+	} else if strings.HasPrefix(string(newConfig.HostConfig.NetworkMode), "service:") ||
+		strings.HasPrefix(string(newConfig.HostConfig.NetworkMode), "container:") {
+		labelNetworkMode = ContainerRefToName(string(newConfig.HostConfig.NetworkMode))
+		AddLabels(newConfig, map[string]string{"cosmos-force-network-mode": labelNetworkMode})
+		if labelNetworkMode != string(newConfig.HostConfig.NetworkMode) {
+			newConfig.HostConfig.NetworkMode = container.NetworkMode(labelNetworkMode)
 		}
-	} else {
-		newConfig.HostConfig.NetworkMode = container.NetworkMode(GetLabel(newConfig, "cosmos-force-network-mode"))
 	}
 	
 	newName := newConfig.Name
@@ -400,10 +413,15 @@ func RecreateDepedencies(containerID, containerName string) {
 			if err != nil {
 				utils.Error("RecreateDepedencies - Failed to update - ", err)
 			}
+			continue
 		}
 
-		// check if network_mode force 's label contains the container name
-		if GetLabel(fullContainer, "cosmos-force-network-mode") == "container:" + containerName[1:] {
+		// check if the cosmos-force-network-mode label references this container
+		// (container:<name> after normalization, or the compose-created
+		// service:<service> alias stored by the compose editor).
+		labelMode := GetLabel(fullContainer, "cosmos-force-network-mode")
+		labelTarget := NetworkModeRefTarget(labelMode)
+		if labelTarget != "" && (labelTarget == containerName[1:] || labelTarget == containerID) {
 			utils.Log("RecreateDepedencies - Recreating " + container.Names[0])
 			_, err := EditContainer(container.ID, fullContainer, true)
 			if err != nil {
@@ -430,6 +448,12 @@ func ListContainers() ([]types.Container, error) {
 }
 
 func AddLabels(containerConfig types.ContainerJSON, labels map[string]string) error {
+	if containerConfig.Config == nil {
+		return errors.New("AddLabels: container config is nil")
+	}
+	if containerConfig.Config.Labels == nil {
+		containerConfig.Config.Labels = make(map[string]string)
+	}
 	for key, value := range labels {
 		containerConfig.Config.Labels[key] = value
 	}
@@ -438,6 +462,9 @@ func AddLabels(containerConfig types.ContainerJSON, labels map[string]string) er
 }
 
 func RemoveLabels(containerConfig types.ContainerJSON, labels []string) error {
+	if containerConfig.Config == nil || containerConfig.Config.Labels == nil {
+		return nil
+	}
 	for _, label := range labels {
 		delete(containerConfig.Config.Labels, label)
 	}
@@ -446,18 +473,18 @@ func RemoveLabels(containerConfig types.ContainerJSON, labels []string) error {
 }
 
 func IsLabel(containerConfig types.ContainerJSON, label string) bool {
-	if containerConfig.Config.Labels[label] == "true" {
-		return true
+	if containerConfig.Config == nil || containerConfig.Config.Labels == nil {
+		return false
 	}
-	return false
+	return containerConfig.Config.Labels[label] == "true"
 }
 func HasLabel(containerConfig types.ContainerJSON, label string) bool {
-	if containerConfig.Config.Labels[label] != "" {
-		return true
-	}
-	return false
+	return GetLabel(containerConfig, label) != ""
 }
 func GetLabel(containerConfig types.ContainerJSON, label string) string {
+	if containerConfig.Config == nil || containerConfig.Config.Labels == nil {
+		return ""
+	}
 	return containerConfig.Config.Labels[label]
 }
 

--- a/src/docker/events.go
+++ b/src/docker/events.go
@@ -159,6 +159,14 @@ func onDockerStarted(containerID string) {
 	utils.Debug("onDockerStarted: " + containerID)
 	BootstrapContainerFromTags(containerID)
 	DebouncedExportDocker()
+
+	// Best-effort depends_on cascade for containers started outside Cosmos
+	// (host reboot, manual `docker start`, ...). Docker's own restart policy
+	// may already be bringing dependents back up; we only fill the gaps for
+	// compose-style depends_on that Docker knows nothing about. Runs in a
+	// goroutine so a long dependency wait never blocks the event loop, and all
+	// failures are logged, not fatal.
+	go ReorderDependedOn(containerID)
 }
 
 func onDockerDestroyed(containerID string) {

--- a/src/docker/events.go
+++ b/src/docker/events.go
@@ -160,12 +160,8 @@ func onDockerStarted(containerID string) {
 	BootstrapContainerFromTags(containerID)
 	DebouncedExportDocker()
 
-	// Best-effort depends_on cascade for containers started outside Cosmos
-	// (host reboot, manual `docker start`, ...). Docker's own restart policy
-	// may already be bringing dependents back up; we only fill the gaps for
-	// compose-style depends_on that Docker knows nothing about. Runs in a
-	// goroutine so a long dependency wait never blocks the event loop, and all
-	// failures are logged, not fatal.
+	// bring stack dependents back for containers started outside Cosmos
+	// (host reboot, manual docker start) — non-blocking, best-effort
 	go ReorderDependedOn(containerID)
 }
 

--- a/src/docker/export.go
+++ b/src/docker/export.go
@@ -131,11 +131,9 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 					return networks
 			}(),
 
-			// depends_on is reconstructed from compose's com.docker.compose.depends_on
-			// label (the internal serialization of the field). The label itself is
-			// stripped from Labels below so the depends_on *field* is the source of
-			// truth the user sees and edits.
-			DependsOn:      DependsOnFieldFromLabels(detailedInfo.Config),
+			// depends_on is reconstructed from the compose label (stripped from
+			// Labels below) so the *field* is the source of truth for the user.
+			DependsOn:      DependsOnFieldFromLabels(detailedInfo.Config, buildContainerNameIndex()),
 			RestartPolicy:  string(detailedInfo.HostConfig.RestartPolicy.Name),
 			Devices:        func() []string {
 					var devices []string
@@ -176,9 +174,7 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 			
 		// }
 
-		// The com.docker.compose.depends_on label is an internal serialization
-		// detail of the depends_on field; hide it so the UI/backup shows the
-		// field (DependsOn), not the label.
+		// hide the internal depends_on label; the field is the source of truth
 		service.Labels = stripInternalDependsOnLabel(service.Labels)
 
 		return service, nil

--- a/src/docker/export.go
+++ b/src/docker/export.go
@@ -131,7 +131,11 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 					return networks
 			}(),
 
-			DependsOn:      map[string]ContainerCreateRequestContainerDependsOnCont{},  // This is not directly available from inspect. It's part of docker-compose.
+			// depends_on is reconstructed from compose's com.docker.compose.depends_on
+			// label (the internal serialization of the field). The label itself is
+			// stripped from Labels below so the depends_on *field* is the source of
+			// truth the user sees and edits.
+			DependsOn:      DependsOnFieldFromLabels(detailedInfo.Config),
 			RestartPolicy:  string(detailedInfo.HostConfig.RestartPolicy.Name),
 			Devices:        func() []string {
 					var devices []string
@@ -171,6 +175,11 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 		// for _, port := range detailedInfo.Config.ExposedPorts {
 			
 		// }
+
+		// The com.docker.compose.depends_on label is an internal serialization
+		// detail of the depends_on field; hide it so the UI/backup shows the
+		// field (DependsOn), not the label.
+		service.Labels = stripInternalDependsOnLabel(service.Labels)
 
 		return service, nil
 }

--- a/src/docker/export.go
+++ b/src/docker/export.go
@@ -49,7 +49,9 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 			}(),
 			Domainname:   detailedInfo.Config.Domainname,
 			MacAddress:   detailedInfo.NetworkSettings.MacAddress,
-			NetworkMode:  string(detailedInfo.HostConfig.NetworkMode),
+			// Normalize container/service refs to stable container:<name>: the
+			// inspect may report a container ID that goes stale on recreate.
+			NetworkMode:  ContainerRefToName(string(detailedInfo.HostConfig.NetworkMode)),
 			StopSignal:   detailedInfo.Config.StopSignal,
 			HealthCheck:  ContainerCreateRequestContainerHealthcheck {
 			},

--- a/src/docker/network_mode_ref.go
+++ b/src/docker/network_mode_ref.go
@@ -32,22 +32,9 @@ func NetworkModeRefTarget(mode string) string {
 	return ""
 }
 
-// ContainerRefToName resolves the target of a "container:<...>" /
-// "service:<...>" network mode to the target container's stable name (without
-// the leading "/"). Non-reference modes are returned unchanged.
-//
-// This is the heart of the container-mode durability fix. Docker accepts both
-// a name and an ID in "container:<ref>", but the daemon does NOT rewrite the
-// stored reference when the target container is recreated — the old ID then
-// points at a deleted container and the network sharing silently breaks
-// (commonly after an update/recreate of the referenced container). The
-// container name, on the other hand, is deliberately stable across recreations
-// (unless the user actively renames it), so we always persist/resolve to the
-// name.
-//
-// If the target cannot be resolved (Docker unreachable, or the container does
-// not exist yet — e.g. a compose stack mid-creation), the input is returned
-// unchanged so a valid setup is never broken by a failed normalization.
+// ContainerRefToName resolves a "container:<ref>" / "service:<ref>" network
+// mode target to its stable container name (IDs go stale on recreate; names
+// do not). Unresolvable refs are returned unchanged.
 func ContainerRefToName(mode string) string {
 	target := NetworkModeRefTarget(mode)
 	if target == "" {
@@ -60,17 +47,12 @@ func ContainerRefToName(mode string) string {
 		return mode
 	}
 
-	// Always normalize to container:<name> — never service:<...>, never an ID.
-	// service: is a compose-only convenience that Docker itself turns into
-	// container:<id> at create time; persisting a container name makes the
-	// reference survive recreations of both containers.
+	// always persist container:<name> (service: and IDs go stale on recreate)
 	return "container:" + name
 }
 
-// ResolveContainerRefToName resolves a container name / full ID / unambiguous
-// ID prefix to its stable name (without the leading "/"). Returns "" when the
-// container cannot be found or Docker is unreachable — callers decide whether
-// to fall back to the original input.
+// ResolveContainerRefToName resolves a container name/ID/prefix to its stable
+// name, or "" when not found / Docker unreachable.
 func ResolveContainerRefToName(ref string) string {
 	if ref == "" {
 		return ""

--- a/src/docker/network_mode_ref.go
+++ b/src/docker/network_mode_ref.go
@@ -1,0 +1,91 @@
+package docker
+
+import (
+	"strings"
+
+	"github.com/azukaar/cosmos-server/src/utils"
+)
+
+// NetworkModeContainerRef returns true when the given docker network mode is a
+// "container:<name-or-id>" reference, i.e. this container shares the network
+// namespace of another container.
+func NetworkModeContainerRef(mode string) bool {
+	return strings.HasPrefix(mode, "container:")
+}
+
+// NetworkModeServiceRef returns true when the given docker network mode is a
+// "service:<name>" reference (compose-style alias for a container reference).
+func NetworkModeServiceRef(mode string) bool {
+	return strings.HasPrefix(mode, "service:")
+}
+
+// NetworkModeRefTarget extracts the referenced container name-or-ID from a
+// "container:<...>" or "service:<...>" network mode. Returns "" when the mode
+// is not a container/service reference.
+func NetworkModeRefTarget(mode string) string {
+	if NetworkModeContainerRef(mode) {
+		return strings.TrimPrefix(mode, "container:")
+	}
+	if NetworkModeServiceRef(mode) {
+		return strings.TrimPrefix(mode, "service:")
+	}
+	return ""
+}
+
+// ContainerRefToName resolves the target of a "container:<...>" /
+// "service:<...>" network mode to the target container's stable name (without
+// the leading "/"). Non-reference modes are returned unchanged.
+//
+// This is the heart of the container-mode durability fix. Docker accepts both
+// a name and an ID in "container:<ref>", but the daemon does NOT rewrite the
+// stored reference when the target container is recreated — the old ID then
+// points at a deleted container and the network sharing silently breaks
+// (commonly after an update/recreate of the referenced container). The
+// container name, on the other hand, is deliberately stable across recreations
+// (unless the user actively renames it), so we always persist/resolve to the
+// name.
+//
+// If the target cannot be resolved (Docker unreachable, or the container does
+// not exist yet — e.g. a compose stack mid-creation), the input is returned
+// unchanged so a valid setup is never broken by a failed normalization.
+func ContainerRefToName(mode string) string {
+	target := NetworkModeRefTarget(mode)
+	if target == "" {
+		return mode
+	}
+
+	name := ResolveContainerRefToName(target)
+	if name == "" {
+		// Unresolvable right now: keep the original value untouched.
+		return mode
+	}
+
+	// Always normalize to container:<name> — never service:<...>, never an ID.
+	// service: is a compose-only convenience that Docker itself turns into
+	// container:<id> at create time; persisting a container name makes the
+	// reference survive recreations of both containers.
+	return "container:" + name
+}
+
+// ResolveContainerRefToName resolves a container name / full ID / unambiguous
+// ID prefix to its stable name (without the leading "/"). Returns "" when the
+// container cannot be found or Docker is unreachable — callers decide whether
+// to fall back to the original input.
+func ResolveContainerRefToName(ref string) string {
+	if ref == "" {
+		return ""
+	}
+
+	if err := Connect(); err != nil {
+		utils.Debug("ResolveContainerRefToName: docker connect failed: " + err.Error())
+		return ""
+	}
+
+	container, err := DockerClient.ContainerInspect(DockerContext, ref)
+	if err != nil {
+		utils.Debug("ResolveContainerRefToName: cannot inspect " + ref + ": " + err.Error())
+		return ""
+	}
+
+	return strings.TrimPrefix(container.Name, "/")
+}

--- a/src/docker/network_mode_ref_test.go
+++ b/src/docker/network_mode_ref_test.go
@@ -1,0 +1,102 @@
+package docker
+
+import (
+	"testing"
+)
+
+func TestNetworkModeContainerRef(t *testing.T) {
+	cases := map[string]bool{
+		"container:foo":    true,
+		"container:abc123": true,
+		"service:foo":      false,
+		"bridge":           false,
+		"host":             false,
+		"":                 false,
+		"cosmos-net":       false,
+	}
+	for in, want := range cases {
+		if got := NetworkModeContainerRef(in); got != want {
+			t.Errorf("NetworkModeContainerRef(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestNetworkModeServiceRef(t *testing.T) {
+	cases := map[string]bool{
+		"service:foo":   true,
+		"container:foo": false,
+		"bridge":        false,
+		"":              false,
+	}
+	for in, want := range cases {
+		if got := NetworkModeServiceRef(in); got != want {
+			t.Errorf("NetworkModeServiceRef(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestNetworkModeRefTarget(t *testing.T) {
+	cases := map[string]string{
+		"container:foo":    "foo",
+		"container:abc123": "abc123",
+		"service:bar":      "bar",
+		"bridge":           "",
+		"host":             "",
+		"":                 "",
+		"container:":       "",
+	}
+	for in, want := range cases {
+		if got := NetworkModeRefTarget(in); got != want {
+			t.Errorf("NetworkModeRefTarget(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ContainerRefToName must leave non-reference modes and unresolvable
+// references untouched, and normalize resolvable refs to container:<name>.
+// The "newName" cases simulate Docker's behavior of accepting both a name and
+// an ID prefix for the same container — without a daemon we cannot exercise
+// ResolveContainerRefToName, so we cover the non-resolution paths here and the
+// resolution path via the daemon-backed integration flows.
+func TestContainerRefToNamePassthrough(t *testing.T) {
+	cases := map[string]string{
+		"bridge":     "bridge",
+		"host":       "host",
+		"default":    "default",
+		"cosmos-net": "cosmos-net",
+		"":           "",
+		"container:": "container:",
+		"service:":   "service:",
+	}
+	for in, want := range cases {
+		if got := ContainerRefToName(in); got != want {
+			t.Errorf("ContainerRefToName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCombineLabelTarget mimics RecreateDepedencies' label matching: after
+// normalization the label holds container:<name>, and a dependent must be
+// recreated when that name (or a compose service alias) matches the recreated
+// container's name.
+func TestCombineLabelTarget(t *testing.T) {
+	containerName := "app-db"
+	cases := []struct {
+		label   string
+		wantHit bool
+	}{
+		{"container:" + containerName, true},
+		{"service:" + containerName, true},
+		{"container:other", false},
+		{"service:other", false},
+		{"container:" + containerName + ":extra", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		target := NetworkModeRefTarget(c.label)
+		hit := target != "" && target == containerName
+		if hit != c.wantHit {
+			t.Errorf("label %q: hit=%v want %v (target=%q)", c.label, hit, c.wantHit, target)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

What this PR fixes:
end-to-end `network_mode: <container>` and `depends_on:` functionality in cosmos compose.
So far, these two features were supported in cosmos, but only at service creation. Any restart or re-creation (incl. automatic updates) would potentially break the container, as depends_on and network_mode weren't taken into account.

There is also a compatibility layer between docker and cosmos compose, as cosmos compose does not differentiate between servicename and containername, but docker compose does.

### What changed

1. **`depends_on` is end-to-end** — persisted in docker-compose's *own* label format (`com.docker.compose.depends_on` = `<svc>:<condition>:<restart>,...`), reconstructed as the `depends_on` **field** for the user (the label is internal and hidden), and honored on create, restart, recreate, update, and boot.
2. **docker-compose parity**:
   - `network_mode: container:X / service:X` is **not** a `depends_on` edge (compose graph = `depends_on` only); in-batch `network_mode` targets become a soft ordering constraint, external targets never hard-error (fixes pihole/tailscale style failures).
   - `service_started` is handled by DAG ordering; only `service_healthy` / `running_or_healthy` / `service_completed_successfully` are waited on.
3. **Restart-of-dependents cascade** (mirrors `pkg/compose/restart.go`) — when a container restarts/recreates: network_mode/ipc/pid namespace sharers always restart; `depends_on restart:true` dependents restart; restart:false is pruned. Scoped to the **same stack** (`cosmos.stack` / `com.docker.compose.project`).
4. **Service-name ↔ container-name resolution** — docker-compose stores `depends_on` by service name + `com.docker.compose.service` per container; Cosmos uses container names. `resolveDepKey`/`DependsOnIncludesTarget` bridge the two so compose-imported stacks work in Cosmos and vice-versa.

### Files
`src/docker/{api_blueprint,api_managecont,api_updateContainer,api_getcontainers,backups,depends_on,docker,events,export,network_mode_ref,network_mode_ref_test,depends_on_test}.go` • `client/src/pages/servapps/servapps.jsx`

### Testing
- `go build ./src/docker/` ✅
- `go test -vet=off ./src/docker/` ✅ (19 tests: label round-trip/parse, condition eval, ordering + cycles, service/container-name resolution, network-mode refs, restart-dependents decision, stack detection)
- Unrelated pre-existing: `src/launcher` `v.ARMMD5` fails to build on `unstable` (untouched).