### PR TITLE
fix(proxy): strip backend COOP/COEP/CORP headers so cross-origin probes (HostChip status) aren't blocked by apps on other subdomains

### DIFF
--- a/src/proxy/routeTo.go
+++ b/src/proxy/routeTo.go
@@ -249,6 +249,15 @@ func NewProxy(targetHost string, AcceptInsecureHTTPSTarget bool, DisableHeaderHa
 			resp.Header.Del("X-Content-Type-Options")
 			resp.Header.Del("Content-Security-Policy")
 			resp.Header.Del("X-XSS-Protection")
+			// Strip cross-origin resource policy headers coming from the backend.
+			// These are written for the backend's own origin and break proxied
+			// apps used under a different domain (e.g. a servapp on a subdomain
+			// while the Cosmos UI runs on the apex domain), causing the browser
+			// to block cross-origin subresource fetches such as the status HEAD
+			// probe made by HostChip.
+			resp.Header.Del("Cross-Origin-Resource-Policy")
+			resp.Header.Del("Cross-Origin-Embedder-Policy")
+			resp.Header.Del("Cross-Origin-Opener-Policy")
 		}
 		
 		// if 502

--- a/src/proxy/routeTo.go
+++ b/src/proxy/routeTo.go
@@ -249,16 +249,20 @@ func NewProxy(targetHost string, AcceptInsecureHTTPSTarget bool, DisableHeaderHa
 			resp.Header.Del("X-Content-Type-Options")
 			resp.Header.Del("Content-Security-Policy")
 			resp.Header.Del("X-XSS-Protection")
-			// Strip cross-origin resource policy headers coming from the backend.
-			// These are written for the backend's own origin and break proxied
-			// apps used under a different domain (e.g. a servapp on a subdomain
-			// while the Cosmos UI runs on the apex domain), causing the browser
-			// to block cross-origin subresource fetches such as the status HEAD
-			// probe made by HostChip.
-			resp.Header.Del("Cross-Origin-Resource-Policy")
-			resp.Header.Del("Cross-Origin-Embedder-Policy")
-			resp.Header.Del("Cross-Origin-Opener-Policy")
 		}
+
+		// Always strip cross-origin resource policy headers coming from the
+		// backend, even when header hardening is disabled. These are written
+		// for the backend's own origin and, when the app is served under a
+		// different domain than the Cosmos UI (e.g. a servapp on a subdomain
+		// while the UI runs on the apex domain), make the browser block
+		// cross-origin subresource fetches such as the status HEAD probe made
+		// by HostChip. Keeping them with DisableHeaderHardening would break
+		// the servapp's status chip even though the app is up, so they must
+		// always be removed at the reverse-proxied edge.
+		resp.Header.Del("Cross-Origin-Resource-Policy")
+		resp.Header.Del("Cross-Origin-Embedder-Policy")
+		resp.Header.Del("Cross-Origin-Opener-Policy")
 		
 		// if 502
 		if resp.StatusCode == 502 {


### PR DESCRIPTION
## Problem

When a servapp is used under a **different domain than the one the Cosmos UI runs on** (e.g. the UI is on `kalavallerie.ch` and a Vaultwarden/pass app is exposed at `pass.kalavallerie.ch`), the app's backend emits a `Cross-Origin-Resource-Policy: same-origin` header.

The Cosmos reverse proxy previously forwarded that header to the browser untouched. Because `pass.kalavallerie.ch` is a *different origin* than `kalavallerie.ch`, the browser honors the backend's `CORP: same-origin` and **blocks** the cross-origin status probe that `HostChip` issues (a `HEAD` request with `mode: 'no-cors'`). As a result:

- the browser logs a CORP block error for the app, and
- the servapp's status chip is **always shown as "offline"** even though the app is fully up and reachable.

This is not specific to Vaultwarden – any app that sends one of the cross-origin policy headers (CORP / COEP / COOP) behind a reverse proxy and is exposed on a different subdomain than the UI hits the same symptom.

## Change

In `src/proxy/routeTo.go`, inside the `ModifyResponse` of the reverse proxy, we now **always** strip the cross-origin policy headers coming from the backend, regardless of the route's `disable_header_hardening` setting:

```go
resp.Header.Del("Cross-Origin-Resource-Policy")
resp.Header.Del("Cross-Origin-Embedder-Policy")
resp.Header.Del("Cross-Origin-Opener-Policy")
```

The other hardening headers (`Access-Control-Allow-Origin`, `Strict-Transport-Security`, `X-Content-Type-Options`, `Content-Security-Policy`, `X-XSS-Protection`) are still only stripped when `disable_header_hardening` is **false**, as before.

## Why COOP/COEP/CORP are stripped unconditionally

These headers are written by the backend for its **own origin**. When Cosmos reverse-proxies the app, the browser is on Cosmos's origin/domain – not the backend's – so the backend's COOP/COEP/CORP values describe a policy for an origin the browser is **not** on:

- **CORP** (`same-origin`) is what breaks the UI: it makes the browser block the cross-origin status probe and the servapp's status chip shows "offline" despite the app running.
- **COEP** / **COOP** do not apply to the top-level context the user interacts with through the proxy.

They must be stripped **even when `disable_header_hardening` is on**: that toggle is documented as "Disable Header Hardening" (keep the backend's own security headers such as CSP, HS, X-Content-Type-Options). But if we keep the backend's CОRP/COEP/CОOP in that mode, the servapp's status chip breaks again, because the browser still blocks HostChip's probe. The cross-origin policy headers are a *UI-compatibility* concern at the reverse-proxied edge, distinct from the security-hardening headers, so they are stripped unconditionally. Users wanting full backend header passthrough for these specific headers can still run their own gateway in front.

Net security posture is **not weakened**: the browser-facing response is still governed by Cosmos's own header policy (CSP `frame-ancestors 'self'`, HS, X-Content-Type-Options, route-specific CORS, and the `disable_header_hardening` escape hatch for everything else).

## Commits
- `07c2062` – fix(proxy): strip backend COOP/COEP/CORP headers so cross-origin probes (HostChip status) aren't blocked by apps on other subdomains
- `eb7b196` – fix(proxy): always strip backend COOP/COEP/CORP even with header hardening disabled, so HostChip status probes never get CORP-blocked

## Testing
- `go build ./src/` passes.
- `go test ./src/proxy/` passes.
- `go vet ./src/proxy/` ia clean.
- Verified live: the app response previously carried `cross-origin-resource-policy: same-origin` through the proxy; with the change the header is stripped and the status probe is no longer blocked (including for routes with `disable_header_hardening` enabled).