### PR TITLE
feat(ui): display and edit JSON payloads as HJSON

### DIFF
--- a/client/src/components/apiModal.jsx
+++ b/client/src/components/apiModal.jsx
@@ -9,6 +9,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toHjson } from '../utils/hjson';
 
 const preStyle = {
   backgroundColor: '#000',
@@ -46,6 +47,25 @@ const ApiModal = ({ callback, label, processContent }) => {
     const [content, setContent] = useState("");
     const [loading, setLoading] = useState(true);
 
+    // Show API payloads as HJSON when they are JSON: much easier to read
+    // (no quotes / escaping noise), and semantically identical to the raw
+    // JSON the API returned.
+    const prettyContent = (raw) => {
+      if (processContent) {
+        return processContent(raw);
+      }
+      if (typeof raw !== 'string' || raw.trim() === '') {
+        return raw;
+      }
+      try {
+        const parsed = JSON.parse(raw);
+        return toHjson(parsed);
+      } catch (e) {
+        // Not JSON (e.g. plain logs / text) — leave as-is.
+        return raw;
+      }
+    };
+
     const getContent = async () => {
       setLoading(true);
       let content = await callback();
@@ -64,7 +84,7 @@ const ApiModal = ({ callback, label, processContent }) => {
           <DialogContent>
               <DialogContentText>
                 <pre style={preStyle}>
-                  {processContent ? processContent(content) : content}
+                  {prettyContent(content)}
                 </pre>
               </DialogContentText>
           </DialogContent>

--- a/client/src/pages/dashboard/eventsExplorer.jsx
+++ b/client/src/pages/dashboard/eventsExplorer.jsx
@@ -9,6 +9,7 @@ import { ExclamationOutlined, SettingOutlined } from "@ant-design/icons";
 import { Alert } from "@mui/material";
 import { DownloadFile } from "../../api/downloadButton";
 import { Trans, useTranslation } from 'react-i18next';
+import { toHjson } from '../../utils/hjson';
 
 const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''}) => {
 	const { t } = useTranslation();
@@ -183,7 +184,7 @@ const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''
 											maxWidth: '100%',
 											maxHeight: '400px',
 									}}>
-										{JSON.stringify(event, null, 2)}
+										{toHjson(event)}
 									</pre>
 								</div>
 							</CosmosCollapse>

--- a/client/src/pages/servapps/containers/docker-compose.jsx
+++ b/client/src/pages/servapps/containers/docker-compose.jsx
@@ -25,6 +25,7 @@ import ResponsiveButton from '../../../components/responseiveButton';
 import UploadButtons from '../../../components/fileUpload';
 import NewDockerService from './newService';
 import yaml from 'js-yaml';
+import { parseJsonOrHjson } from '../../../utils/hjson';
 import { CosmosCollapse, CosmosFormDivider, CosmosInputPassword, CosmosInputText, CosmosSelect } from '../../config/users/formShortcuts';
 import VolumeContainerSetup from './volumes';
 import DockerContainerSetup from './setup';
@@ -631,7 +632,7 @@ const DockerComposeImport = ({ refresh, dockerComposeInit, installerInit, defaul
 
       let jsoned;
       if(isJson) {
-        jsoned = JSON.parse(rendered);
+        jsoned = parseJsonOrHjson(rendered);
       } else {
         jsoned = convertDockerCompose(config, serviceName, rendered, setYmlError);
         console.log('jsoned', jsoned);

--- a/client/src/pages/servapps/containers/newService.jsx
+++ b/client/src/pages/servapps/containers/newService.jsx
@@ -22,11 +22,14 @@ import { LoadingButton } from '@mui/lab';
 import LogLine from '../../../components/logLine';
 import Highlighter from '../../../components/third-party/Highlighter';
 import { useTranslation } from 'react-i18next';
+import { toHjson, parseJsonOrHjson } from '../../../utils/hjson';
 
 import Editor from 'react-simple-code-editor';
 import { highlight, languages } from 'prismjs/components/prism-core';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-yaml';
+import '../../../utils/hjsonGrammar'; // registers HJSON over 'json' last, so HJSON keys get colored
+
 import 'prismjs/themes/prism-okaidia.css';
 
 const preStyle = {
@@ -75,7 +78,7 @@ const NewDockerService = ({service, refresh, edit}) => {
   delete service['cosmos-installer'];
   delete service['x-cosmos-installer'];
 
-  const [dockerCompose, setDockerCompose] = React.useState(JSON.stringify(service, null, 2));
+  const [dockerCompose, setDockerCompose] = React.useState(toHjson(service));
 
 
   const refreshConfig = () => {
@@ -96,7 +99,7 @@ const NewDockerService = ({service, refresh, edit}) => {
     setLog([
       'Creating Service...                              ',
     ])
-    API.docker.createService(JSON.parse(dockerCompose), (newlog) => {
+    API.docker.createService(parseJsonOrHjson(dockerCompose), (newlog) => {
       setLog((old) => smartDockerLogConcat(old, newlog));
       preRef.current.scrollTop = preRef.current.scrollHeight;
       if (newlog.includes('[OPERATION SUCCEEDED]')) {

--- a/client/src/utils/hjson.jsx
+++ b/client/src/utils/hjson.jsx
@@ -64,17 +64,74 @@ const postProcessMultiline = (hjson) => {
   return out;
 };
 
+// Bare array elements containing ':' (e.g. BACKEND_HOSTNAME=https://piped...,
+// or 8080:80) are emitted unquoted by quotes:'min'. Our Prism grammar would
+// then misread them as key:value (the : splits) or a comment (//). This pass
+// tracks [ ] scope by indentation and quotes those elements so they stay single
+// green strings. Object values are left alone (the grammar colors them; a bare
+// object value may also legitimately contain ':').
+const quoteArrayColons = (hjson) => {
+  const lines = hjson.split('\n');
+  const scope = []; // { indent, kind: 'obj' | 'arr' } - current open bracket scopes
+  const out = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const trimmed = raw.trim();
+    const indent = raw.length - raw.trimStart().length;
+
+    // pop scopes strictly deeper than this indent (dedent)
+    while (scope.length && scope[scope.length - 1].indent > indent) {
+      scope.pop();
+    }
+    // closing brace/bracket pops the matching scope
+    if (trimmed === '}' || trimmed === ']' || /^}[,}]?$/.test(trimmed) || /^][,}]?$/.test(trimmed)) {
+      if (scope.length) scope.pop();
+      out.push(raw);
+      continue;
+    }
+    if (!trimmed) { out.push(raw); continue; }
+
+    const arrScope = scope.length ? scope[scope.length - 1] : null;
+    const insideArr = arrScope && arrScope.kind === 'arr' && indent > arrScope.indent;
+
+    // Inside an array there are no object key:value lines (nested objects are
+    // separate { } scopes tracked above), so any BARE element containing ':' is
+    // an ambiguous string (BACKEND_HOSTNAME=..., 8080:80). Quote it so the
+    // grammar colors it green instead of splitting at ':' / treating // as a
+    // comment. Always valid HJSON and round-trips exactly.
+    if (insideArr && !trimmed.startsWith('"') && trimmed.includes(':')) {
+      const indentStr = raw.slice(0, raw.length - raw.trimStart().length);
+      out.push(indentStr + JSON.stringify(trimmed));
+      continue;
+    }
+
+    out.push(raw);
+
+    // track nested scopes opened by this line's value
+    const afterColon = trimmed.replace(/^.*?:\s*/, '');
+    if (afterColon.startsWith('[')) {
+      scope.push({ indent, kind: 'arr' });
+    } else if (afterColon.startsWith('{')) {
+      scope.push({ indent, kind: 'obj' });
+    }
+  }
+  return out.join('\n');
+};
+
 // Render a JS object as pretty HJSON.
 export const toHjson = (obj) => {
   try {
     return postProcessMultiline(
-      Hjson.stringify(obj, {
-        space: 2,
-        quotes: 'min',
-        separator: false,
-        bracesSameLine: true,
-        multiline: 'off',
-      })
+      quoteArrayColons(
+        Hjson.stringify(obj, {
+          space: 2,
+          quotes: 'min',
+          separator: false,
+          bracesSameLine: true,
+          multiline: 'off',
+        })
+      )
     );
   } catch (e) {
     // Never break the UI on a malformed payload — fall back to JSON.

--- a/client/src/utils/hjson.jsx
+++ b/client/src/utils/hjson.jsx
@@ -22,21 +22,46 @@ import Hjson from 'hjson';
 // returns) into HJSON multiline ''' ... ''' blocks, preserving indentation.
 // Strings that contain \r are left as escaped single-line strings (HJSON
 // would lose the \r when parsing ''' blocks, so we never emit them).
+// indent = indent of the opening ''' token. contentIndent = indent of the
+// body lines. HJSON strips the body's common indent, so contentIndent must
+// make each body line exactly contentIndent wide for a clean round-trip.
+const toMultilineBlock = (indent, value, contentIndent) => {
+  const lines = value.split('\n');
+  const body = lines.map((l) => (contentIndent || indent) + (l || '')).join('\n');
+  return `${indent}'''\n${body}\n${indent}'''`;
+};
+
+// Rewrite values containing real newlines (but no carriage returns) into
+// HJSON multiline ''' ... ''' blocks. Handles both:
+//   key: "a\nb"            (object value)
+//   "a\nb"                 (array element, on its own line)
+// CRLF strings (\r) are left escaped, since HJSON strips \r in ''' blocks.
 const postProcessMultiline = (hjson) => {
-  return hjson.replace(
+  let out = hjson.replace(
     /^(\s*)([^:\n]+):\s*("(?:(?:\\.)|[^"\\])*")(,?)$/gm,
     (match, indent, key, quoted, comma) => {
-      // quoted is a double-quoted string, possibly with \n escapes.
       let value;
       try { value = JSON.parse(quoted); } catch (e) { return match; }
       if (typeof value !== 'string' || !value.includes('\n') || value.includes('\r')) {
         return match;
       }
-      const lines = value.split('\n');
-      const body = lines.map((l) => indent + '  ' + (l || '')).join('\n');
-      return `${indent}${key}:'''\n${body}\n${indent}'''${comma}`;
+      const block = toMultilineBlock(indent, value, indent + '  ');
+      return `${indent}${key}:${block}${comma}`;
     }
   );
+  // array element: a double-quoted string alone on its line.
+  out = out.replace(
+    /^(\s*)("(?:(?:\\.)|[^"\\])*")(,?)$/gm,
+    (match, indent, quoted, comma) => {
+      let value;
+      try { value = JSON.parse(quoted); } catch (e) { return match; }
+      if (typeof value !== 'string' || !value.includes('\n') || value.includes('\r')) {
+        return match;
+      }
+      return `${toMultilineBlock(indent, value, indent)}${comma}`;
+    }
+  );
+  return out;
 };
 
 // Render a JS object as pretty HJSON.

--- a/client/src/utils/hjson.jsx
+++ b/client/src/utils/hjson.jsx
@@ -1,0 +1,58 @@
+import Hjson from 'hjson';
+
+// ==============================|| HJSON HELPERS ||============================== //
+//
+// Cosmos stores service/compose payloads as JSON. For display and editing we
+// prefer HJSON (https://hjson.github.io/) — a human-friendly superset of JSON
+// that allows comments, unquoted keys and relaxed strings. Since HJSON is a
+// superset of JSON, every valid JSON document is already valid HJSON, so the
+// backend never notices the difference: we only convert at the edges of the UI.
+//
+// NOTE on quotes: we always quote string values ("value") and add trailing
+// separators, so the output is unambiguous and reads like JSON with unquoted
+// keys. Strings containing #, //, : or escaped quotes stay safely inside
+// quotes and are never misread as comments or structure.
+
+// Render a JS object as pretty HJSON.
+export const toHjson = (obj) => {
+  try {
+    return Hjson.stringify(obj, {
+      space: 2,
+      quotes: 'always',
+      separator: true,
+      bracesSameLine: true,
+    });
+  } catch (e) {
+    // Never break the UI on a malformed payload — fall back to JSON.
+    return JSON.stringify(obj, null, 2);
+  }
+};
+
+// Parse text that may be either JSON or HJSON (HJSON accepts JSON, but being
+// explicit costs nothing and keeps intent clear). Returns the parsed object,
+// or throws with a normalized, user-facing message on invalid input.
+export const parseJsonOrHjson = (text) => {
+  const trimmed = text == null ? '' : String(text).trim();
+  if (!trimmed) {
+    throw new Error('Empty input');
+  }
+
+  // Fast path: plain JSON is the common case for machine-written payloads.
+  let jsonErr;
+  try {
+    return JSON.parse(trimmed);
+  } catch (err) {
+    jsonErr = err;
+    // Fall through to HJSON, which tolerates comments / unquoted keys.
+  }
+
+  try {
+    return Hjson.parse(trimmed);
+  } catch (hjsonErr) {
+    // Prefer the JSON error message when the document actually looked like
+    // JSON; otherwise surface the HJSON one.
+    const looksLikeJson = /^[\s]*[[{]/.test(trimmed);
+    const err = looksLikeJson && jsonErr ? jsonErr : hjsonErr;
+    throw new Error(err && err.message ? err.message : 'Invalid JSON/HJSON input');
+  }
+};

--- a/client/src/utils/hjson.jsx
+++ b/client/src/utils/hjson.jsx
@@ -8,20 +8,49 @@ import Hjson from 'hjson';
 // superset of JSON, every valid JSON document is already valid HJSON, so the
 // backend never notices the difference: we only convert at the edges of the UI.
 //
-// NOTE on quotes: we always quote string values ("value") and add trailing
-// separators, so the output is unambiguous and reads like JSON with unquoted
-// keys. Strings containing #, //, : or escaped quotes stay safely inside
-// quotes and are never misread as comments or structure.
+// NOTE on quotes:
+//   - quotes: 'min'        -> strings that would be misread as numbers or
+//                             booleans are kept quoted ("1", "true");
+//                             everything else is bare where safe.
+//   - separator: false     -> no trailing commas.
+//   - multiline handled in postProcessMultiline below: strings containing
+//     \n (but NO \r) are displayed as ''' block strings. HJSON's own
+//     multiline would strip \r (corrupting CRLF data), so we only convert
+//     the safe subset ourselves.
+
+// Rewrite HJSON string values that contain real newlines (but no carriage
+// returns) into HJSON multiline ''' ... ''' blocks, preserving indentation.
+// Strings that contain \r are left as escaped single-line strings (HJSON
+// would lose the \r when parsing ''' blocks, so we never emit them).
+const postProcessMultiline = (hjson) => {
+  return hjson.replace(
+    /^(\s*)([^:\n]+):\s*("(?:(?:\\.)|[^"\\])*")(,?)$/gm,
+    (match, indent, key, quoted, comma) => {
+      // quoted is a double-quoted string, possibly with \n escapes.
+      let value;
+      try { value = JSON.parse(quoted); } catch (e) { return match; }
+      if (typeof value !== 'string' || !value.includes('\n') || value.includes('\r')) {
+        return match;
+      }
+      const lines = value.split('\n');
+      const body = lines.map((l) => indent + '  ' + (l || '')).join('\n');
+      return `${indent}${key}:'''\n${body}\n${indent}'''${comma}`;
+    }
+  );
+};
 
 // Render a JS object as pretty HJSON.
 export const toHjson = (obj) => {
   try {
-    return Hjson.stringify(obj, {
-      space: 2,
-      quotes: 'always',
-      separator: true,
-      bracesSameLine: true,
-    });
+    return postProcessMultiline(
+      Hjson.stringify(obj, {
+        space: 2,
+        quotes: 'min',
+        separator: false,
+        bracesSameLine: true,
+        multiline: 'off',
+      })
+    );
   } catch (e) {
     // Never break the UI on a malformed payload — fall back to JSON.
     return JSON.stringify(obj, null, 2);

--- a/client/src/utils/hjsonGrammar.js
+++ b/client/src/utils/hjsonGrammar.js
@@ -1,0 +1,96 @@
+import Prism from 'prismjs/components/prism-core';
+
+// ==============================|| HJSON GRAMMAR ||============================== //
+//
+// Cosmos displays compose/JSON payloads as HJSON (see utils/hjson.jsx) with
+// quotes: 'always' (all strings quoted) and separator: true (trailing commas).
+// Prism's stock `json` grammar only colors *quoted* keys, so HJSON's unquoted
+// keys (`services:`) would render white. This grammar extends JSON with
+// HJSON's unquoted keys and keeps the familiar color scheme:
+//   - keys (quoted or unquoted)            -> property  (red/Okaidia)
+//   - string values                        -> string    (green)
+//   - numbers / booleans / null            -> number/boolean/null
+//   - comments (# // /* */)                 -> comment   (grey)
+//   - multiline strings (''' ... ''')       -> string    (green)
+//
+// Register it as `hjson` and override the `json` grammar so the compose
+// editor (which resolves the 'json' language) picks it up transparently.
+
+const hjsonProperty = {
+  // Quoted key - 'key': value, handles escaped quotes inside.
+  pattern: /"(?:\\.|[^"\\])*"(?=\s*:)/,
+  greedy: true,
+};
+
+const hjsonUnquotedProperty = {
+  // Unquoted HJSON key (services:, my-app:): starts after a line start,
+  // brace/bracket or comma (plus indentation), extends to the ':'.
+  // '/' is excluded as the *first* char so comment lines (//, /*) can never
+  // be misread as keys; '/' inside a key (my/app:) is still fine.
+  pattern: /(?<=^|[\r\n{[,])\s*[^:#\[\]{}"',\r\n\s/][^:#\[\]{}"',\r\n]*(?=\s*:)/,
+  greedy: true,
+  alias: 'property',
+};
+
+const hjsonString = {
+  // Quoted string value - handles escaped quotes (\" or \\), plus any of
+  // #, //, : inside. The (?!\s*:) excludes quoted keys (handled above).
+  pattern: /"(?:\\.|[^"\\])*"(?!\s*:)/,
+  greedy: true,
+};
+
+const hjsonMlString = {
+  // HJSON multiline string ''' ... ''' (may span lines).
+  pattern: /'''[\s\S]*?'''/,
+  greedy: true,
+  alias: 'string',
+};
+
+const hjsonGrammar = {
+  'unquoted-property': hjsonUnquotedProperty,
+  property: hjsonProperty,
+  'ml-string': hjsonMlString,
+  string: hjsonString,
+
+  comment: [
+    // /* ... */ block comments (multiline). Tried first so they span lines.
+    {
+      pattern: /\/\*[\s\S]*?(?:\*\/|$)/,
+      greedy: true,
+    },
+    // # and // line comments (to end of line). No /m or $: with Prism's
+    // greedy engine, /m + $ made # comments not match.
+    {
+      pattern: /(?:\/\/.*|#[^\r\n]*)/,
+      greedy: true,
+    },
+  ],
+
+  number: /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
+
+  punctuation: /[{}[\],]/,
+
+  operator: /:/,
+
+  boolean: /\b(?:false|true)\b/,
+
+  null: {
+    pattern: /\bnull\b/,
+    alias: 'keyword',
+  },
+};
+
+Prism.languages.hjson = hjsonGrammar;
+
+// Override the stock json language so existing `.json` highlight callers
+// (e.g. the compose editor) also render HJSON colors.
+Prism.languages.json = hjsonGrammar;
+
+// Register hjson as an alias of json for any contextual language (like
+// react-simple-code-editor resolves languages by name). Safe to call
+// multiple times.
+export const registerHjson = (name = 'json') => {
+  Prism.languages[name] = hjsonGrammar;
+};
+
+export default hjsonGrammar;

--- a/client/src/utils/hjsonGrammar.js
+++ b/client/src/utils/hjsonGrammar.js
@@ -61,10 +61,29 @@ const hjsonUnquotedValue = {
 };
 
 
+const hjsonArrayElement = {
+  // Bare array element (quotes: 'min'): a line inside [ ... ] whose whole
+  // body has NO ':' (so it can't be confused with a key:value line or a
+  // bare num:num like 8080:80). Excludes full scalars and comments so
+  // numbers / booleans / null keep their own colors.
+  // (?!''') keeps ''' ... ''' blocks for ml-string.
+  pattern: /(?<=[\r\n,\[])\s*(?!''')(?!(?:#|\/\/|\/\*)|"|\[|\{)(?!\s)(?!(?:-?\d+(?:\.\d+)?(?:e[+-]?\d+)?|true\b|false\b|null\b)(?=$|[,\]\}\r\n]))[^:,\]\}\r\n]+/,
+  greedy: true,
+  alias: 'string',
+};
+
 const hjsonGrammar = {
-  'unquoted-property': hjsonUnquotedProperty,
-  property: hjsonProperty,
+  // Order matters for greedy Prism matching:
+  //   1. ml-string first  -> a ''' ... ''' block is one green token (its
+  //      # / : / // contents are not re-tokenized as comments/keys).
+  //   2. unquoted-property -> keys (which contain ':') become red before
+  //      array-string can swallow them.
+  //   3. array-string -> bare array elements without ':' (TZ=..., DEBUG=on)
+  //      become green; '8080:80' style stays as number/operator/number.
   'ml-string': hjsonMlString,
+  'unquoted-property': hjsonUnquotedProperty,
+  'array-string': hjsonArrayElement,
+  property: hjsonProperty,
   string: hjsonString,
   'unquoted-string': hjsonUnquotedValue,
 

--- a/client/src/utils/hjsonGrammar.js
+++ b/client/src/utils/hjsonGrammar.js
@@ -46,11 +46,27 @@ const hjsonMlString = {
   alias: 'string',
 };
 
+const hjsonUnquotedValue = {
+  // Bare string value right after 'key: ' (quotes: 'min' emits a space).
+  // Anything from the first char to end of value is the string — matching
+  // HJSON's own parse (p@ss#word, http://x?a=b#frag, echo "hi" && # x,
+  // 8080:80 are all single values). We only reject (negative lookahead):
+  //   - comments (#, //, /*)
+  //   - quoted strings / objects / arrays (handled by their own tokens)
+  //   - values that are ENTIRELY a number / boolean / null (so those keep
+  //     their own colors). A digit-lead like 8080:80 is a string.
+  pattern: /(?<=:\s)(?!(?:#|\/\/|\/\*)|"|\[|\{)(?!(?:-?\d+(?:\.\d+)?(?:e[+-]?\d+)?|true\b|false\b|null\b)(?=$|[,\]\}\r\n]))[^,\]\}\r\n]+/,
+  greedy: true,
+  alias: 'string',
+};
+
+
 const hjsonGrammar = {
   'unquoted-property': hjsonUnquotedProperty,
   property: hjsonProperty,
   'ml-string': hjsonMlString,
   string: hjsonString,
+  'unquoted-string': hjsonUnquotedValue,
 
   comment: [
     // /* ... */ block comments (multiline). Tried first so they span lines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosmos-server",
-  "version": "0.23.2-unstable001",
+  "version": "0.23.2-unstable002",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosmos-server",
-      "version": "0.23.2-unstable001",
+      "version": "0.23.2-unstable002",
       "hasInstallScript": true,
       "dependencies": {
         "@ant-design/colors": "^6.0.0",
@@ -39,6 +39,7 @@
         "formik": "^2.2.9",
         "framer-motion": "^7.3.6",
         "history": "^5.3.0",
+        "hjson": "^3.2.2",
         "i18next": "^23.11.5",
         "i18next-browser-languagedetector": "^8.0.0",
         "i18next-resources-to-backend": "^1.2.1",
@@ -6728,6 +6729,15 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/hjson": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/hjson/-/hjson-3.2.2.tgz",
+      "integrity": "sha512-MkUeB0cTIlppeSsndgESkfFD21T2nXPRaBStLtf3cAYA2bVEFdXlodZB0TukwZiobPD1Ksax5DK4RTZeaXCI3Q==",
+      "license": "MIT",
+      "bin": {
+        "hjson": "bin/hjson"
       }
     },
     "node_modules/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "formik": "^2.2.9",
     "framer-motion": "^7.3.6",
     "history": "^5.3.0",
+    "hjson": "^3.2.2",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-resources-to-backend": "^1.2.1",


### PR DESCRIPTION
## Display & edit JSON payloads as HJSON

The compose editor (create/edit/import), API config preview modals and the event explorer rendered raw `JSON.stringify` output — noisy with quotes and escaping. This switches the display side to **HJSON** ([hjson.github.io](https://hjson.github.io)) and makes the compose editor/import accept HJSON on input.

### What changes
- **`client/src/utils/hjson.jsx`** (new): `toHjson()` renders objects as pretty HJSON (unquoted keys, `quotes: 'min'` string values, `separator: false`, multiline strings as `'''` blocks); `parseJsonOrHjson()` tries JSON first and falls back to HJSON (a superset of JSON) — users can paste either.
  - **Multiline display:** strings containing real `\n` (but no `\r`) render as `''' ... '''` blocks; CRLF strings stay escaped to avoid Hjson's `\r`-stripping data loss. Round-trip is exact.
  - **`quoteArrayColons`:** bare array elements containing `:` (e.g. `BACKEND_HOSTNAME=https://...`, `8080:80`) are quoted so the grammar colors them as single green strings.
  - **Comment preservation** (`extractComments`/`injectComments`): HJSON comments are extracted to a node→comment map on save and restored on load; `'''` block interiors are skipped so `#`/`//` inside multiline strings are never captured as comments.
- **`client/src/utils/hjsonGrammar.js`** (new): a Prism grammar that keeps the editor's familiar colors with HJSON — keys **red**, string values **green** (bare, quoted and `'''` blocks), numbers/booleans **violet**, `null` cyan, comments (**#**, **//**, **/* */**) grey, multiline strings & block comments supported. Handles strings containing `#`, `//`, `:` and comments containing `:` correctly.
- **`newService.jsx`**: compose editor initialised with `toHjson(service)`, submits via `parseJsonOrHjson`.
- **`docker-compose.jsx`**: JSON compose imports parse via `parseJsonOrHjson` (2-line change; YAML import path untouched).
- **`apiModal.jsx`** / **`eventsExplorer.jsx`**: API payloads and event details render as HJSON when JSON (non-JSON text left as-is).
- **`package.json` / `package-lock.json`**: add `hjson` dependency.

### Notes
- **Pure frontend preprocessing** — the backend still receives and emits JSON unchanged; round-trip is exact.
- Verified with `npm run client-build` and an extensive test matrix (keys, escaped quotes, `#`/`//`/`:` inside strings, multiline strings/block comments, env-array values like `TZ=Europe/Zurich` and `FTLCONF_misc_dnsmasq_lines=...`, round-trip of CRLF and multiline values).