### PR TITLE
feat(docker): show user-set vs image-default config in the compose editor

### DIFF
--- a/client/src/api/docker.tsx
+++ b/client/src/api/docker.tsx
@@ -181,13 +181,14 @@ export default function createDockerAPI(apiFetch: ApiFetch, createWs: (path: str
     }))
   }
 
-  function exportContainer(containerId: string, values: any): Promise<ApiResponse> {
-    return wrap(apiFetch('/cosmos/api/servapps/' + containerId + '/export', {
+  function exportContainer(containerId: string, from?: 'initial' | 'runtime'): Promise<ApiResponse> {
+    // from=initial returns the config the user actually set (container vs
+    // image-config diff); from=runtime returns the full live runtime state.
+    return wrap(apiFetch(`/cosmos/api/servapps/${containerId}/export?from=${from || 'initial'}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(values),
     }))
   }
 

--- a/client/src/components/apiModal.jsx
+++ b/client/src/components/apiModal.jsx
@@ -9,6 +9,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toHjson } from '../utils/hjson';
 
 const preStyle = {
   backgroundColor: '#000',
@@ -46,6 +47,25 @@ const ApiModal = ({ callback, label, processContent }) => {
     const [content, setContent] = useState("");
     const [loading, setLoading] = useState(true);
 
+    // Show API payloads as HJSON when they are JSON: much easier to read
+    // (no quotes / escaping noise), and semantically identical to the raw
+    // JSON the API returned.
+    const prettyContent = (raw) => {
+      if (processContent) {
+        return processContent(raw);
+      }
+      if (typeof raw !== 'string' || raw.trim() === '') {
+        return raw;
+      }
+      try {
+        const parsed = JSON.parse(raw);
+        return toHjson(parsed);
+      } catch (e) {
+        // Not JSON (e.g. plain logs / text) — leave as-is.
+        return raw;
+      }
+    };
+
     const getContent = async () => {
       setLoading(true);
       let content = await callback();
@@ -64,7 +84,7 @@ const ApiModal = ({ callback, label, processContent }) => {
           <DialogContent>
               <DialogContentText>
                 <pre style={preStyle}>
-                  {processContent ? processContent(content) : content}
+                  {prettyContent(content)}
                 </pre>
               </DialogContentText>
           </DialogContent>

--- a/client/src/pages/dashboard/eventsExplorer.jsx
+++ b/client/src/pages/dashboard/eventsExplorer.jsx
@@ -9,6 +9,7 @@ import { ExclamationOutlined, SettingOutlined } from "@ant-design/icons";
 import { Alert } from "@mui/material";
 import { DownloadFile } from "../../api/downloadButton";
 import { Trans, useTranslation } from 'react-i18next';
+import { toHjson } from '../../utils/hjson';
 
 const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''}) => {
 	const { t } = useTranslation();
@@ -183,7 +184,7 @@ const EventsExplorer = ({from, to, xAxis, zoom, slot, initLevel, initSearch = ''
 											maxWidth: '100%',
 											maxHeight: '400px',
 									}}>
-										{JSON.stringify(event, null, 2)}
+										{toHjson(event)}
 									</pre>
 								</div>
 							</CosmosCollapse>

--- a/client/src/pages/servapps/containers/compose-editor.jsx
+++ b/client/src/pages/servapps/containers/compose-editor.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Alert, Checkbox, Chip, CircularProgress, Stack, Typography, useMediaQuery } from '@mui/material';
+import { Alert, FormControlLabel, Stack, Switch, Typography, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import MainCard from '../../../components/MainCard';
 import * as API from '../../../api';
 import NewDockerService from './newService';
@@ -8,6 +9,7 @@ import { useClientInfos } from '../../../utils/hooks';
 import { useTranslation } from 'react-i18next';
 
 const ContainerComposeEdit = ({ containerInfo, config, refresh, updatesAvailable, selfName }) => {
+  const theme = useTheme();
   const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));
   const [isUpdating, setIsUpdating] = React.useState(false);
   const { hasPermission, hasRolePermission } = useClientInfos();
@@ -16,17 +18,21 @@ const ContainerComposeEdit = ({ containerInfo, config, refresh, updatesAvailable
   const { Name } = containerInfo;
 
   const [exportedCompose, setExportedCompose] = React.useState(null);
+  // false = show the config the user actually set (container vs image-config
+  // diff: only explicitly-set values). true = show the live Docker runtime
+  // state (everything Docker resolved, including image defaults).
+  const [showRuntime, setShowRuntime] = React.useState(false);
 
   React.useEffect(() => {
     if (!hasPermission(PERM_CREDENTIALS_READ)) return;
-    API.docker.exportContainer(Name.replace('/', '')).then((res) => {
+    API.docker.exportContainer(Name.replace('/', ''), showRuntime ? 'runtime' : 'initial').then((res) => {
       setExportedCompose({
         services: {
           [Name.replace('/', '')]: res.data
         }
       });
     });
-  }, [Name]);
+  }, [Name, showRuntime]);
 
   let refreshAll = refresh ? (() => refresh().then(() => {
     setIsUpdating(false);
@@ -46,6 +52,44 @@ const ContainerComposeEdit = ({ containerInfo, config, refresh, updatesAvailable
 
   return (
     <div style={{ maxWidth: '1000px', width: '100%', margin: 'auto' }}>
+      <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <Typography variant="caption" color="text.secondary">
+          {showRuntime
+            ? 'Showing live runtime values (including image defaults)'
+            : 'Showing values that were explicitly set (image defaults excluded)'}
+        </Typography>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={showRuntime}
+              onChange={(e) => setShowRuntime(e.target.checked)}
+              size="small"
+              sx={{
+                '& .MuiSwitch-switchBase.Mui-checked': {
+                  color: theme.palette.primary.main,
+                  '&:hover': { backgroundColor: theme.palette.primary.main + '22' },
+                },
+                '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+                  backgroundColor: theme.palette.primary.main,
+                  opacity: 1,
+                },
+                '& .MuiSwitch-track': {
+                  backgroundColor: theme.palette.mode === 'dark'
+                    ? theme.palette.grey[600]
+                    : theme.palette.grey[400],
+                  opacity: 1,
+                },
+              }}
+            />
+          }
+          label={
+            <Typography variant="body2" sx={{ color: theme.palette.text.primary }}>
+              Show runtime values
+            </Typography>
+          }
+          sx={{ '& .MuiFormControlLabel-label': { color: theme.palette.text.primary } }}
+        />
+      </Stack>
       {exportedCompose && <NewDockerService edit service={exportedCompose} refresh={refreshAll} />}
     </div>
   );

--- a/client/src/pages/servapps/containers/docker-compose.jsx
+++ b/client/src/pages/servapps/containers/docker-compose.jsx
@@ -25,6 +25,7 @@ import ResponsiveButton from '../../../components/responseiveButton';
 import UploadButtons from '../../../components/fileUpload';
 import NewDockerService from './newService';
 import yaml from 'js-yaml';
+import { parseJsonOrHjson } from '../../../utils/hjson';
 import { CosmosCollapse, CosmosFormDivider, CosmosInputPassword, CosmosInputText, CosmosSelect } from '../../config/users/formShortcuts';
 import VolumeContainerSetup from './volumes';
 import DockerContainerSetup from './setup';
@@ -631,7 +632,7 @@ const DockerComposeImport = ({ refresh, dockerComposeInit, installerInit, defaul
 
       let jsoned;
       if(isJson) {
-        jsoned = JSON.parse(rendered);
+        jsoned = parseJsonOrHjson(rendered);
       } else {
         jsoned = convertDockerCompose(config, serviceName, rendered, setYmlError);
         console.log('jsoned', jsoned);

--- a/client/src/pages/servapps/containers/newService.jsx
+++ b/client/src/pages/servapps/containers/newService.jsx
@@ -80,6 +80,21 @@ const NewDockerService = ({service, refresh, edit}) => {
 
   const [dockerCompose, setDockerCompose] = React.useState(toHjson(service));
 
+  // The service prop can change after mount — the Compose editor re-fetches
+  // the exported definition when the user toggles between the configured
+  // (diff-based) view and the runtime view. useState only captures the initial
+  // value, so sync the editor content whenever a *different* service object
+  // arrives. The JSON key comparison avoids clobbering in-progress edits on
+  // unrelated re-renders.
+  const serviceKey = React.useMemo(() => JSON.stringify(service), [service]);
+  const serviceKeyRef = React.useRef(serviceKey);
+  React.useEffect(() => {
+    if (serviceKeyRef.current !== serviceKey) {
+      serviceKeyRef.current = serviceKey;
+      setDockerCompose(toHjson(service));
+    }
+  }, [serviceKey, service]);
+
 
   const refreshConfig = () => {
     API.config.get().then((res) => {

--- a/client/src/pages/servapps/containers/newService.jsx
+++ b/client/src/pages/servapps/containers/newService.jsx
@@ -22,11 +22,14 @@ import { LoadingButton } from '@mui/lab';
 import LogLine from '../../../components/logLine';
 import Highlighter from '../../../components/third-party/Highlighter';
 import { useTranslation } from 'react-i18next';
+import { toHjson, parseJsonOrHjson } from '../../../utils/hjson';
 
 import Editor from 'react-simple-code-editor';
 import { highlight, languages } from 'prismjs/components/prism-core';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-yaml';
+import '../../../utils/hjsonGrammar'; // registers HJSON over 'json' last, so HJSON keys get colored
+
 import 'prismjs/themes/prism-okaidia.css';
 
 const preStyle = {
@@ -75,7 +78,7 @@ const NewDockerService = ({service, refresh, edit}) => {
   delete service['cosmos-installer'];
   delete service['x-cosmos-installer'];
 
-  const [dockerCompose, setDockerCompose] = React.useState(JSON.stringify(service, null, 2));
+  const [dockerCompose, setDockerCompose] = React.useState(toHjson(service));
 
 
   const refreshConfig = () => {
@@ -96,7 +99,7 @@ const NewDockerService = ({service, refresh, edit}) => {
     setLog([
       'Creating Service...                              ',
     ])
-    API.docker.createService(JSON.parse(dockerCompose), (newlog) => {
+    API.docker.createService(parseJsonOrHjson(dockerCompose), (newlog) => {
       setLog((old) => smartDockerLogConcat(old, newlog));
       preRef.current.scrollTop = preRef.current.scrollHeight;
       if (newlog.includes('[OPERATION SUCCEEDED]')) {

--- a/client/src/utils/hjson.jsx
+++ b/client/src/utils/hjson.jsx
@@ -1,0 +1,58 @@
+import Hjson from 'hjson';
+
+// ==============================|| HJSON HELPERS ||============================== //
+//
+// Cosmos stores service/compose payloads as JSON. For display and editing we
+// prefer HJSON (https://hjson.github.io/) — a human-friendly superset of JSON
+// that allows comments, unquoted keys and relaxed strings. Since HJSON is a
+// superset of JSON, every valid JSON document is already valid HJSON, so the
+// backend never notices the difference: we only convert at the edges of the UI.
+//
+// NOTE on quotes: we always quote string values ("value") and add trailing
+// separators, so the output is unambiguous and reads like JSON with unquoted
+// keys. Strings containing #, //, : or escaped quotes stay safely inside
+// quotes and are never misread as comments or structure.
+
+// Render a JS object as pretty HJSON.
+export const toHjson = (obj) => {
+  try {
+    return Hjson.stringify(obj, {
+      space: 2,
+      quotes: 'always',
+      separator: true,
+      bracesSameLine: true,
+    });
+  } catch (e) {
+    // Never break the UI on a malformed payload — fall back to JSON.
+    return JSON.stringify(obj, null, 2);
+  }
+};
+
+// Parse text that may be either JSON or HJSON (HJSON accepts JSON, but being
+// explicit costs nothing and keeps intent clear). Returns the parsed object,
+// or throws with a normalized, user-facing message on invalid input.
+export const parseJsonOrHjson = (text) => {
+  const trimmed = text == null ? '' : String(text).trim();
+  if (!trimmed) {
+    throw new Error('Empty input');
+  }
+
+  // Fast path: plain JSON is the common case for machine-written payloads.
+  let jsonErr;
+  try {
+    return JSON.parse(trimmed);
+  } catch (err) {
+    jsonErr = err;
+    // Fall through to HJSON, which tolerates comments / unquoted keys.
+  }
+
+  try {
+    return Hjson.parse(trimmed);
+  } catch (hjsonErr) {
+    // Prefer the JSON error message when the document actually looked like
+    // JSON; otherwise surface the HJSON one.
+    const looksLikeJson = /^[\s]*[[{]/.test(trimmed);
+    const err = looksLikeJson && jsonErr ? jsonErr : hjsonErr;
+    throw new Error(err && err.message ? err.message : 'Invalid JSON/HJSON input');
+  }
+};

--- a/client/src/utils/hjsonGrammar.js
+++ b/client/src/utils/hjsonGrammar.js
@@ -1,0 +1,96 @@
+import Prism from 'prismjs/components/prism-core';
+
+// ==============================|| HJSON GRAMMAR ||============================== //
+//
+// Cosmos displays compose/JSON payloads as HJSON (see utils/hjson.jsx) with
+// quotes: 'always' (all strings quoted) and separator: true (trailing commas).
+// Prism's stock `json` grammar only colors *quoted* keys, so HJSON's unquoted
+// keys (`services:`) would render white. This grammar extends JSON with
+// HJSON's unquoted keys and keeps the familiar color scheme:
+//   - keys (quoted or unquoted)            -> property  (red/Okaidia)
+//   - string values                        -> string    (green)
+//   - numbers / booleans / null            -> number/boolean/null
+//   - comments (# // /* */)                 -> comment   (grey)
+//   - multiline strings (''' ... ''')       -> string    (green)
+//
+// Register it as `hjson` and override the `json` grammar so the compose
+// editor (which resolves the 'json' language) picks it up transparently.
+
+const hjsonProperty = {
+  // Quoted key - 'key': value, handles escaped quotes inside.
+  pattern: /"(?:\\.|[^"\\])*"(?=\s*:)/,
+  greedy: true,
+};
+
+const hjsonUnquotedProperty = {
+  // Unquoted HJSON key (services:, my-app:): starts after a line start,
+  // brace/bracket or comma (plus indentation), extends to the ':'.
+  // '/' is excluded as the *first* char so comment lines (//, /*) can never
+  // be misread as keys; '/' inside a key (my/app:) is still fine.
+  pattern: /(?<=^|[\r\n{[,])\s*[^:#\[\]{}"',\r\n\s/][^:#\[\]{}"',\r\n]*(?=\s*:)/,
+  greedy: true,
+  alias: 'property',
+};
+
+const hjsonString = {
+  // Quoted string value - handles escaped quotes (\" or \\), plus any of
+  // #, //, : inside. The (?!\s*:) excludes quoted keys (handled above).
+  pattern: /"(?:\\.|[^"\\])*"(?!\s*:)/,
+  greedy: true,
+};
+
+const hjsonMlString = {
+  // HJSON multiline string ''' ... ''' (may span lines).
+  pattern: /'''[\s\S]*?'''/,
+  greedy: true,
+  alias: 'string',
+};
+
+const hjsonGrammar = {
+  'unquoted-property': hjsonUnquotedProperty,
+  property: hjsonProperty,
+  'ml-string': hjsonMlString,
+  string: hjsonString,
+
+  comment: [
+    // /* ... */ block comments (multiline). Tried first so they span lines.
+    {
+      pattern: /\/\*[\s\S]*?(?:\*\/|$)/,
+      greedy: true,
+    },
+    // # and // line comments (to end of line). No /m or $: with Prism's
+    // greedy engine, /m + $ made # comments not match.
+    {
+      pattern: /(?:\/\/.*|#[^\r\n]*)/,
+      greedy: true,
+    },
+  ],
+
+  number: /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
+
+  punctuation: /[{}[\],]/,
+
+  operator: /:/,
+
+  boolean: /\b(?:false|true)\b/,
+
+  null: {
+    pattern: /\bnull\b/,
+    alias: 'keyword',
+  },
+};
+
+Prism.languages.hjson = hjsonGrammar;
+
+// Override the stock json language so existing `.json` highlight callers
+// (e.g. the compose editor) also render HJSON colors.
+Prism.languages.json = hjsonGrammar;
+
+// Register hjson as an alias of json for any contextual language (like
+// react-simple-code-editor resolves languages by name). Safe to call
+// multiple times.
+export const registerHjson = (name = 'json') => {
+  Prism.languages[name] = hjsonGrammar;
+};
+
+export default hjsonGrammar;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosmos-server",
-  "version": "0.23.2-unstable001",
+  "version": "0.23.2-unstable002",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cosmos-server",
-      "version": "0.23.2-unstable001",
+      "version": "0.23.2-unstable002",
       "hasInstallScript": true,
       "dependencies": {
         "@ant-design/colors": "^6.0.0",
@@ -39,6 +39,7 @@
         "formik": "^2.2.9",
         "framer-motion": "^7.3.6",
         "history": "^5.3.0",
+        "hjson": "^3.2.2",
         "i18next": "^23.11.5",
         "i18next-browser-languagedetector": "^8.0.0",
         "i18next-resources-to-backend": "^1.2.1",
@@ -6728,6 +6729,15 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/hjson": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/hjson/-/hjson-3.2.2.tgz",
+      "integrity": "sha512-MkUeB0cTIlppeSsndgESkfFD21T2nXPRaBStLtf3cAYA2bVEFdXlodZB0TukwZiobPD1Ksax5DK4RTZeaXCI3Q==",
+      "license": "MIT",
+      "bin": {
+        "hjson": "bin/hjson"
       }
     },
     "node_modules/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "formik": "^2.2.9",
     "framer-motion": "^7.3.6",
     "history": "^5.3.0",
+    "hjson": "^3.2.2",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-resources-to-backend": "^1.2.1",

--- a/src/docker/api_containers.go
+++ b/src/docker/api_containers.go
@@ -80,7 +80,20 @@ func ExportContainerRoute(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		service, err := ExportContainer(containerID)
+		// from=initial returns the config the user actually set (container vs
+		// image-config diff). from=runtime returns the full live runtime state.
+		from := req.URL.Query().Get("from")
+		if from == "" {
+			from = "initial"
+		}
+
+		var service ContainerCreateRequestContainer
+		var err error
+		if from == "runtime" {
+			service, err = ExportContainer(containerID)
+		} else {
+			service, err = ExportContainerRuntime(containerID)
+		}
 		if err != nil {
 			utils.Error("exportContainer: Error while exporting container", err)
 			utils.HTTPError(w, "Container Export Error: "+err.Error(), http.StatusInternalServerError, "EC002")

--- a/src/docker/export.go
+++ b/src/docker/export.go
@@ -173,6 +173,138 @@ func ExportContainer(containerID string) (ContainerCreateRequestContainer, error
 		return service, nil
 }
 
+// ExportContainerRuntime exports the service definition containing only the
+// settings that were EXPLICITLY set when the container was created, as
+// opposed to values implicitly inherited from the image's Dockerfile.
+//
+// It does this by diffing the running container's config (ContainerInspect)
+// against the image's own config (ImageInspectWithRaw):
+//   - env vars: only entries that are not present in the image env, or whose
+//     value differs from the image default, are kept (image-inherited ENV and
+//     Cosmos-injected TZ/normalized vars are dropped).
+//   - labels: only labels that are not in the image labels are kept, then
+//     Cosmos bookkeeping labels (cosmos.* / com.docker.compose.*) are dropped.
+//   - command / entrypoint: kept only when they differ from the image's.
+//   - working dir / user / stop signal / hostname / domainname / mac address:
+//     kept only when they differ from the image's.
+//   - healthcheck: kept only when it differs from the image's.
+//
+// Fields that are inherently runtime (ports, volumes, networks, resource
+// limits, restart policy, dns, etc.) have no image-config baseline and are
+// exported as-is — they represent the container's actual wiring.
+//
+// If the image cannot be inspected (deleted, retagged, or not present
+// locally), we fall back to the full runtime export so the compose editor
+// still gets a usable document.
+func ExportContainerRuntime(containerID string) (ContainerCreateRequestContainer, error) {
+	service, err := ExportContainer(containerID)
+	if err != nil {
+		return service, err
+	}
+
+	// Fetch detailed info again to get the container config + resolve the image.
+	detailedInfo, err := DockerClient.ContainerInspect(DockerContext, containerID)
+	if err != nil {
+		ExportError = "Export Docker - Cannot inspect container" + containerID + " - " + err.Error()
+		return ContainerCreateRequestContainer{}, errors.New(ExportError)
+	}
+	if detailedInfo.Config == nil {
+		return service, nil
+	}
+
+	image, _, imgErr := DockerClient.ImageInspectWithRaw(DockerContext, detailedInfo.Config.Image)
+	if imgErr != nil || image.Config == nil {
+		// Image unavailable — cannot diff; return the full runtime export.
+		return service, nil
+	}
+	imgConfig := image.Config
+
+	// Environment: keep user-set / overridden entries only.
+	if len(imgConfig.Env) > 0 {
+		imgEnv := map[string]string{}
+		for _, e := range imgConfig.Env {
+			parts := strings.SplitN(e, "=", 2)
+			if len(parts) == 2 {
+				imgEnv[parts[0]] = parts[1]
+			}
+		}
+		filtered := []string{}
+		for _, e := range service.Environment {
+			parts := strings.SplitN(e, "=", 2)
+			if len(parts) != 2 {
+				filtered = append(filtered, e)
+				continue
+			}
+			k, v := parts[0], parts[1]
+			if imgV, present := imgEnv[k]; !present || imgV != v {
+				filtered = append(filtered, e)
+			}
+		}
+		service.Environment = filtered
+	}
+
+	// Labels: keep only labels not in the image, then drop Cosmos-internal ones.
+	if len(imgConfig.Labels) > 0 {
+		filtered := map[string]string{}
+		for k, v := range service.Labels {
+			if imgV, present := imgConfig.Labels[k]; present && imgV == v {
+				continue // inherited from image
+			}
+			// drop Cosmos bookkeeping labels
+			if strings.HasPrefix(k, "cosmos.") || strings.HasPrefix(k, "com.docker.compose.") {
+				continue
+			}
+			filtered[k] = v
+		}
+		service.Labels = filtered
+	}
+
+	// Command / Entrypoint: keep only if they differ from the image's.
+	containerCmd := strings.Join(detailedInfo.Config.Cmd, " ")
+	imgCmd := strings.Join(imgConfig.Cmd, " ")
+	if containerCmd != "" && containerCmd == imgCmd {
+		service.Command = ""
+	}
+	containerEntry := strings.Join(detailedInfo.Config.Entrypoint, " ")
+	imgEntry := strings.Join(imgConfig.Entrypoint, " ")
+	if containerEntry != "" && containerEntry == imgEntry {
+		service.Entrypoint = ""
+	}
+
+	// WorkingDir / User / StopSignal / Hostname / Domainname / MacAddress.
+	if imgConfig.WorkingDir != "" && detailedInfo.Config.WorkingDir == imgConfig.WorkingDir {
+		service.WorkingDir = ""
+	}
+	if imgConfig.User != "" && detailedInfo.Config.User == imgConfig.User {
+		service.User = ""
+		service.UID = 0
+		service.GID = 0
+	}
+	if imgConfig.StopSignal != "" && detailedInfo.Config.StopSignal == imgConfig.StopSignal {
+		service.StopSignal = ""
+	}
+	if imgConfig.Hostname != "" && detailedInfo.Config.Hostname == imgConfig.Hostname {
+		service.Hostname = ""
+	}
+	if imgConfig.Domainname != "" && detailedInfo.Config.Domainname == imgConfig.Domainname {
+		service.Domainname = ""
+	}
+
+	// Healthcheck: keep only if it differs from the image's.
+	if imgConfig.Healthcheck != nil {
+		if detailedInfo.Config.Healthcheck != nil &&
+			strings.Join(detailedInfo.Config.Healthcheck.Test, " ") == strings.Join(imgConfig.Healthcheck.Test, " ") &&
+			detailedInfo.Config.Healthcheck.Interval == imgConfig.Healthcheck.Interval &&
+			detailedInfo.Config.Healthcheck.Timeout == imgConfig.Healthcheck.Timeout &&
+			detailedInfo.Config.Healthcheck.Retries == imgConfig.Healthcheck.Retries &&
+			detailedInfo.Config.Healthcheck.StartPeriod == imgConfig.Healthcheck.StartPeriod {
+			service.HealthCheck = ContainerCreateRequestContainerHealthcheck{}
+		}
+	}
+
+	return service, nil
+}
+
 func ExportDocker() {
 	config := utils.GetMainConfig()
 	if config.NewInstall {


### PR DESCRIPTION
## Show configured (user-set) vs runtime values in the compose editor

Currently the compose editor always shows the live Docker runtime state, which mixes what the user explicitly configured with values implicitly inherited from the image's Dockerfile (ENV, CMD, EXPOSE, HEALTHCHECK, WORKDIR, USER, etc.) and Cosmos-internal bookkeeping labels.

Instead of persisting a Cosmos-specific snapshot label, this derives what the user actually set by **diffing the running container's config against the image's own config**.

### Backend
- **`ExportContainerRuntime`** (new): exports only the settings that were explicitly set at create time, comparing `ContainerInspect` vs `ImageInspectWithRaw`:
  - **env**: keep only entries not present in the image env or with a different value (image-inherited ENV and Cosmos-injected TZ/normalized vars dropped)
  - **labels**: keep only labels not in the image; drop `cosmos.*` / `com.docker.compose.*` bookkeeping labels
  - **command / entrypoint / workingdir / user / stopsignal / hostname / domainname / healthcheck**: kept only when they differ from the image's
  - **inherently-runtime fields** (ports, volumes, networks, resources, restart, dns, etc.) have no image baseline and are exported as-is — they represent the container's actual wiring
  - falls back to the full runtime export if the image is unavailable (deleted/retagged)
- **`ExportContainerRoute`**: `?from=initial` (default) uses the diff; `?from=runtime` uses the full live runtime export

### Frontend
- **`docker.tsx`**: `exportContainer` now takes `from?: 'initial' | 'runtime'`
- **`compose-editor.jsx`**: adds a **"Show runtime values"** switch that re-fetches the diff vs the full runtime view (themed for dark/light)
- **`newService.jsx`**: re-syncs the editor when the `service` prop changes, so the toggle actually updates the document

### Notes
- **Depends on #584 (Display & edit JSON payloads as HJSON).** This branch is stacked on #584's head (`3e27b37`), so the diff here includes the HJSON commit. Once #584 merges into `unstable`, GitHub will show only this PR's delta.
- Correctly distinguishes user-set from Dockerfile/daemon defaults **without** a Cosmos-specific label, so it also works for containers created outside Cosmos.
- No label persistence, no schema change. Backend + client build clean.