### PR TITLE
fix(docker): parse bind IP from colon-separated port string

### DIFF
--- a/src/docker/api_blueprint.go
+++ b/src/docker/api_blueprint.go
@@ -576,8 +576,8 @@ func CreateService(serviceRequest DockerServiceCreateRequest, OnLog func(string)
 			containerPorts = generatePorts(ports[len(ports)-1])
 
 			ipExposed := ""
-			if len(portStuff) > 2 {
-				ipExposed = strings.Join(portStuff[0:len(portStuff)-2], ":")
+			if len(ports) > 2 {
+				ipExposed = strings.Join(ports[0:len(ports)-2], ":")
 			}
 
 			for i := 0; i < utils.Max(len(hostPorts), len(containerPorts)); i++ {


### PR DESCRIPTION
## What

When creating a servapp with a port bound to a specific host IP, e.g. `192.168.0.1:53:53/tcp`, Cosmos still tried to bind to `0.0.0.0:53:53/tcp` and therefore failed (`failed to bind host port 0.0.0.0:53/udp: address already in use`) whenever that port was not free on **all** host interfaces.

## Root cause

In `src/docker/api_blueprint.go` (`CreateService`), the host IP was parsed from the **wrong split dimension**:

```go
ports := strings.Split(port, ":")        // e.g. ["192.168.0.1","53","53"]
hostPorts = generatePorts(ports[len(ports)-2])
containerPorts = generatePorts(ports[len(ports)-1])

ipExposed := ""
if len(portStuff) > 2 {                // portStuff = split on "/"!
    ipExposed = strings.Join(portStuff[0:len(portStuff)-2], ":")
}
```

The IP lives in the colon-split `port` string, but the code checked `portStuff` (split on `/`). For `192.168.0.1:53:53/tcp`:
- `portStuff` = `["192.168.0.1:53:53", "tcp"]` → `len ==  ized2`, so the `len > 2` guard never fires
- → **`ipExposed` was always `""`** → binding created as `0.0.0.0:53:53/tcp`

That's exactly the reported failure — and it also explains why nothing showed up in `lsof`: the bind never succeeded in the first place.



## Fix

```go
ipExposed := ""
if len(ports) > 2 {
    ipExposed = strings.Join(ports[0:len(ports)-2], ":")
}
```

Extracts the host IP from the colon-split parts (everything before the `hostPort:containerPort` pair). This also correctly handles IPv6 bind addresses (which contain colons).

Verified with a Go simulation:

| input | before | after |
|---|---|---|---|
| `192.168.0.1:53:53/tcp` | `@53:53/tcp` → bound on `0.0.0.0` | `192.168.0.1@53:53/tcp` → bound on custom IP ✅ |
| `8080:80/tcp` | `@8080:80` | `@8080:80` (unchanged) ✅ |
| `[2001:db8::1]:53:53/udp` | broken | `[2001:db8::1]@53:53/udp` — IPv6 ✅ |

`go build ./src/...` passes.