### PR TITLE
fix(api): stop 45s timeout from killing long-running streaming installs

### DIFF
--- a/src/utils/middleware.go
+++ b/src/utils/middleware.go
@@ -103,9 +103,44 @@ func CleanBannedIPs() {
 	})
 }
 
+// IsStreamingEndpoint reports whether the request targets a long-running
+// streaming endpoint (install/service create, container update/recreate,
+// image pulls). These endpoints stream progress over minutes and must not be
+// cut off by the short MiddlewareTimeout.
+func IsStreamingEndpoint(r *http.Request) bool {
+	p := r.URL.Path
+	if strings.HasPrefix(p, "/cosmos/api/docker-service") {
+		return true
+	}
+	if strings.HasPrefix(p, "/cosmos/api/servapps/") {
+		// /api/servapps/{containerId}/manage/{action} and
+		// /api/servapps/{containerId}/update stream progress (image pull,
+		// recreate). Logs, terminal, and plain GETs are fast or WebSocket.
+		if strings.Contains(p, "/manage/") || strings.HasSuffix(p, "/update") {
+			return true
+		}
+	}
+	if strings.HasPrefix(p, "/cosmos/api/images/pull") {
+		// /api/images/pull and /api/images/pull-if-missing stream pull progress.
+		return true
+	}
+	return false
+}
+
 func MiddlewareTimeout(timeout time.Duration) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
+			if IsStreamingEndpoint(r) {
+				// Long-running streaming endpoints (install, container
+				// update/recreate, image pulls) can legitimately exceed the
+				// short API timeout. The operation itself runs against a
+				// background context, so skipping the deadline only stops us
+				// from killing the stream mid-progress and surfacing a bogus
+				// "Gateway Timeout" (HTTP002) to the UI.
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			ctx, cancel := context.WithTimeout(r.Context(), timeout)
 			defer func() {
 				cancel()

--- a/src/utils/middleware_test.go
+++ b/src/utils/middleware_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsStreamingEndpoint(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/cosmos/api/docker-service", true},
+		{"/cosmos/api/docker-service/extra", true},
+		{"/cosmos/api/servapps/myapp/manage/update", true},
+		{"/cosmos/api/servapps/myapp/manage/recreate", true},
+		{"/cosmos/api/servapps/myapp/update", true},
+		{"/cosmos/api/images/pull", true},
+		{"/cosmos/api/images/pull-if-missing", true},
+		// Non-streaming endpoints keep the short timeout.
+		{"/cosmos/api/servapps", false},
+		{"/cosmos/api/servapps/myapp", false},
+		{"/cosmos/api/servapps/myapp/logs", false},
+		{"/cosmos/api/servapps/myapp/terminal/attach", false},
+		{"/cosmos/api/config", false},
+		{"/cosmos/api/markets", false},
+		{"/cosmos/api/users", false},
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest("POST", c.path, nil)
+		if got := IsStreamingEndpoint(req); got != c.want {
+			t.Errorf("IsStreamingEndpoint(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #542 — but the problem is **not exclusive to Miniflux**. The root cause is a server-side API timeout that cuts off **any** long-running, streaming operation.

### Problem

`SecureAPI` registers `utils.MiddlewareTimeout(45 * time.Second)` as a global middleware on all authenticated API routes (`src/httpServer.go`). The middleware wraps the request in a 45s context and, on expiry, writes an error into the response:

```go
HTTPError(w, "Gateway Timeout", http.StatusGatewayTimeout, "HTTP002")
```

Several operations legitimately take longer than 45 seconds and **stream progress back to the UI over a long-lived HTTP response**:

- Installing/creating a service — `/cosmos/api/docker-service` (pulls images, creates containers, waits for dependencies, runs migrations)
- Updating/recreating a container — `/api/servapps/{id}/manage/{action}` (image pull + recreate)
- Updating a container — `/api/servapps/{id}/update`
- Pulling an image — `/api/images/pull`, `/api/images/pull-if-missing`

When the 45s deadline fires mid-stream, the deferred middleware handler writes a bogus `504 Gateway Timeout` (`HTTP002`) into the **open stream**, even though the backend operation is still running fine against its own background context. The UI sees the timeout, shows a failure, and may trigger a rollback — so legitimate installs of apps with multiple images, slow image pulls, or slow first-boot migrations (e.g. Miniflux with its Postgres dependency) fail with `HTTP002` even though they would have completed.

### Fix

Long-running streaming endpoints now **bypass `MiddlewareTimeout`**:

- The Docker operations already run against `DockerContext` (a background context independent of the HTTP request), so not applying a request deadline only prevents the stream from being cut mid-progress — it does not remove any cancellation of the work itself.
- Non-streaming API calls keep the existing 45s timeout unchanged, so short endpoints are still protected against hung handlers.

Added `IsStreamingEndpoint()` which recognizes the streaming routes, and unit-tested it.

### Files changed

- `src/utils/middleware.go` — skip `MiddlewareTimeout` for streaming endpoints
- `src/utils/middleware_test.go` — new unit test for `IsStreamingEndpoint`

The change is intentionally generic: it fixes slow installs / updates / image pulls for any app, not just Miniflux. Miniflux is used in the issue only as the concrete example that exposed it.