### PR TITLE
fix(ui): preserve market listing scroll position when opening app overlay

### DIFF
--- a/client/src/components/ScrollTop.jsx
+++ b/client/src/components/ScrollTop.jsx
@@ -1,14 +1,70 @@
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
 // ==============================|| NAVIGATION - SCROLL TO TOP ||============================== //
 
+const isMarketRoute = (p) => {
+    const segments = p.split('/').filter(Boolean);
+    return segments.length >= 2 && segments[0] === 'cosmos-ui' && segments[1] === 'market-listing';
+};
+
+// The market listing is exactly /cosmos-ui/market-listing (no app segments)
+const isMarketListing = (p) => {
+    const segments = p.split('/').filter(Boolean);
+    return segments.length === 2 && segments[0] === 'cosmos-ui' && segments[1] === 'market-listing';
+};
+
 const ScrollTop = ({ children }) => {
     const location = useLocation();
     const { pathname } = location;
+    const prevPathname = useRef(pathname);
+    const savedMarketScroll = useRef(0);
+
+    // While on the market listing, track the user's scroll position so we can
+    // restore it when the detail overlay is opened (the route change to
+    // /market-listing/:store/:name resets the window scroll to 0, which would
+    // otherwise jump the listing back to the top behind the overlay).
+    useEffect(() => {
+        if (isMarketListing(pathname)) {
+            const onScroll = () => {
+                savedMarketScroll.current = window.scrollY;
+            };
+            window.addEventListener('scroll', onScroll, { passive: true });
+            return () => window.removeEventListener('scroll', onScroll);
+        }
+    }, [pathname]);
 
     useEffect(() => {
+        const prevIsMarket = isMarketRoute(prevPathname.current);
+        const nextIsMarket = isMarketRoute(pathname);
+        const prevIsListing = isMarketListing(prevPathname.current);
+        const nextIsListing = isMarketListing(pathname);
+
+        const togglingMarketOverlay = prevIsMarket && nextIsMarket;
+
+        prevPathname.current = pathname;
+
+        if (togglingMarketOverlay) {
+            // Opening (listing -> detail) or closing (detail -> listing): the
+            // listing stays mounted behind the overlay. The route change makes
+            // the browser reset the window scroll to 0 asynchronously (after
+            // paint), so a single restore gets overwritten. Keep trying until
+            // the scroll sticks, with a final fallback on popstate.
+            const saved = savedMarketScroll.current;
+            let attempts = 0;
+            const tryRestore = () => {
+                attempts++;
+                window.scrollTo(0, saved);
+                if (attempts < 10 && window.scrollY !== saved) {
+                    requestAnimationFrame(tryRestore);
+                }
+            };
+            requestAnimationFrame(tryRestore);
+            window.addEventListener('popstate', tryRestore, { once: true });
+            return;
+        }
+
         window.scrollTo({
             top: 0,
             left: 0,

--- a/client/src/pages/market/listing.jsx
+++ b/client/src/pages/market/listing.jsx
@@ -164,7 +164,9 @@ const MarketPage = () => {
   let openedApp = null;
   if (appName && Object.keys(apps).length > 0) {
     openedApp = apps[appStore].find((app) => app.name === appName);
-    openedApp.appstore = appStore;
+    if (openedApp) {
+      openedApp.appstore = appStore;
+    }
   }
 
   let appList = apps && Object.keys(apps).reduce((acc, appstore) => {
@@ -261,6 +263,7 @@ const MarketPage = () => {
             </Button>
           </Link>
 
+          {openedApp && <>
           <div style={{ textAlign: 'center' }}>
             <Screenshots screenshots={openedApp.screenshots} isAdmin={isAdmin}/>
           </div>
@@ -295,6 +298,7 @@ const MarketPage = () => {
           <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(openedApp?.translation?.[i18n?.resolvedLanguage]?.longDescription || openedApp?.translation?.[i18n?.resolvedLanguage.substr?.(0,2)]?.longDescription || openedApp.longDescription) }}></div>
 
           <DockerComposeImport installerInit defaultName={openedApp.name} dockerComposeInit={openedApp.compose} />
+          </>}
         </Stack>
       </Stack>
     </Box>}


### PR DESCRIPTION
## Summary

Fixes https://github.com/azukaar/Cosmos-Server/issues/208

Opening an app from the market listing **scrolls the page to the top and flashes dark** on the very first click. The detail panel is rendered as an overlay on top of the listing, so the user should keep their place on the list.

**Root cause:** navigating from `/cosmos-ui/market-listing/` to `/cosmos-ui/market-listing/:appStore/:appName` resets `window.scrollY` to `0` **asynchronously** (after paint). A single `scrollTo` restore gets overwritten by the browser's late reset. The listing actually stays mounted behind the overlay, so the jump + the overlay backdrop painting over the moved content is what reads as the "dark flash".

## Fix

`client/src/components/ScrollTop.jsx`:
- Track the listing's `window.scrollY` while on the exact listing path (`/cosmos-ui/market-listing`).
- When toggling between the listing and its detail overlay (opening **or** closing), restore the saved scroll position, **retrying on animation frames until it sticks** (bounded), with a `popstate` fallback — this beats the browser's asynchronous reset.
- Genuine page navigations still scroll to top as before.

`client/src/pages/market/listing.jsx`:
- Guard the market detail render: only assign `openedApp.appstore` (and only render the detail body) when the app is actually found in the loaded data. Prevents a crash on stale/deep-linked detail URLs; the backdrop + Close button still render so the overlay stays dismissible.

## Verification

Reproduced in a headless browser against the local demo build:
- Scroll the listing down → first click on an app card → `window.scrollY` preserved (no jump to top).
- Close the overlay → scroll position still preserved.
- Second/open clicks → same behavior.

## Commits

- `fix(ui): preserve market listing scroll position when opening app overlay`
- `fix(ui): guard market detail render when app is not found`