### PR TITLE
fix(ui): decode URL-encoded segments in breadcrumbs

### DIFF
--- a/client/src/components/@extended/Breadcrumbs.jsx
+++ b/client/src/components/@extended/Breadcrumbs.jsx
@@ -19,11 +19,22 @@ const Breadcrumbs = ({ navigation, title, ...others }) => {
     const [item, setItem] = useState();
     let subItem = '';
 
-    // extract /servapps/stack/:stack
-    const subPath = location.pathname.split('/')[3];
-    if(subPath && location.pathname.split('/')[4]) {
+    // React Router gives us the raw (URL-encoded) pathname; decode segments
+    // (e.g. "My%20Backup" -> "My Backup") before showing them in the UI.
+    const decodePathSegment = (segment) => {
+        try {
+            return decodeURIComponent(segment);
+        } catch (e) {
+            // malformed percent-encoding (e.g. a bare "%"): show as-is
+            return segment;
+        }
+    };
+
+    const pathSegments = location.pathname.split('/');
+    const subPath = pathSegments[3];
+    if(subPath && pathSegments[4]) {
         subItem = <Typography variant="subtitle1" color="textPrimary">
-            {location.pathname.split('/')[4]}
+            {decodePathSegment(pathSegments[4])}
         </Typography>;
     }
 
@@ -93,7 +104,7 @@ const Breadcrumbs = ({ navigation, title, ...others }) => {
                                 </Typography>
                                 {mainContent}
                                 {itemContent}
-                                {subPath && <Typography variant="subtitle1" color="textPrimary">{subPath}</Typography>}
+                                {subPath && <Typography variant="subtitle1" color="textPrimary">{decodePathSegment(subPath)}</Typography>}
                                 {subItem}
                             </MuiBreadcrumbs>
                         </Grid>


### PR DESCRIPTION
## Problem

Backup names (or any path segment) containing spaces — or other URL-reserved characters — render as their **percent-encoded** form in the breadcrumb trail.

Example: navigating to a backup named `My Backup` produces the URL `/cosmos-ui/backups/My%20Backup/...`, and the breadcrumb shows `My%20Backup` instead of `My Backup`.

**Root cause:** `client/src/components/@extended/Breadcrumbs.jsx` renders `location.pathname` segments directly. `location.pathname` is the raw (URL-encoded) pathname; the browser never decodes it automatically.

## Fix

Decode each path segment (`split('/')[3]` and `[4]`) with `decodeURIComponent` before display, wrapped in a safe helper that falls back to the raw segment if the encoding is malformed (e.g. a bare `%`), so the UI can never crash on a weird path.

```jsx
const decodePathSegment = (segment) => {
    try {
        return decodeURIComponent(segment);
    } catch (e) {
        // malformed percent-encoding (e.g. a bare "%"): show as-is
        return segment;
    }
};
```

Both the subPath (`[3]`) and subItem (`[4]`) displays are covered. Display-only change — navigation/link URLs are untouched.

Verified: `vite build` passes cleanly.