### PR TITLE
fix(ui): restore ServApp action button tooltips (update, pause, stop, restart, recreate, kill, delete)

### DIFF
--- a/client/src/pages/servapps/actionBar.jsx
+++ b/client/src/pages/servapps/actionBar.jsx
@@ -157,7 +157,12 @@ const GetActions = ({
     {!isUpdating && actions.filter((action) => {
       return action.if.includes(state) || (updateAvailable && action.if.includes('update_available')) || (!updateAvailable && action.if.includes('update_not_available'));
     }).map((action) => {
-      return (!isStack || !action.hideStack) && <Tooltip title={action.t}>{isStack ? (action.es ? action.es : action.e) : action.e}</Tooltip>
+      const button = isStack ? (action.es ? action.es : action.e) : action.e;
+      return (!isStack || !action.hideStack) && (
+        <Tooltip key={action.t} title={action.t}>
+          <span style={{ display: 'inline-flex' }}>{button}</span>
+        </Tooltip>
+      );
     })}
 
     {isUpdating && <Stack sx={{

--- a/client/src/pages/servapps/deleteModal.jsx
+++ b/client/src/pages/servapps/deleteModal.jsx
@@ -270,6 +270,8 @@ const DeleteModal = ({Ids, containers, refreshServApps, setIsUpdatingId, config}
         </Dialog>
      </>}
 
+     <Tooltip title={t('global.delete')}>
+     <span style={{ display: 'inline-flex' }}>
      <PermissionGuard permission={PERM_RESOURCES}>
        <IconButton onClick={() => {
             setIsOpen(true);
@@ -281,6 +283,8 @@ const DeleteModal = ({Ids, containers, refreshServApps, setIsUpdatingId, config}
           <DeleteOutlined />
         </IconButton>
      </PermissionGuard>
+     </span>
+     </Tooltip>
   </>
 }
 


### PR DESCRIPTION
## Summary

On the ServApps page the action buttons (**update, pause, stop, restart, recreate/revert, kill, delete**) only showed their icon with no tooltip on hover.

The buttons were already wrapped in MUI `<Tooltip>`, but the tooltips were silently broken at runtime.

## Root cause

MUI `Tooltip` works by cloning its direct child and injecting hover/touch/focus event handlers plus a ref into it (see `handleRef` via `useForkRef`, and the injected `onMouseOver`/`onTouchStart`/`onTouchEnd`/`onFocus` props in `@mui/material/Tooltip`).

In `actionBar.jsx` the **direct child of every `Tooltip` was `PermissionGuard`** — a plain function component that renders its children back verbatim but never forwards `ref`/event props to the inner `IconButton`. The injected handlers were dropped, the Tooltip never found a DOM node to attach to, so no tooltip rendered.

This is a regression from **v0.22** (`daeef5d7`), when `PermissionGuard` was introduced between the `Tooltip` and the `IconButton`. Before that the Tooltip wrapped the `IconButton` directly and worked.

## Fix

Wrap each button in a real DOM `<span style="display:inline-flex">` so the `Tooltip` has an element to attach its handlers/ref to:

- **`client/src/pages/servapps/actionBar.jsx`** — the action `.map()` render now wraps every button in a `<span>`, and adds a `key` (required for the array mapping). Covers update, pause, stop, restart, recreate, kill, plus the stack variant.
- **`client/src/pages/servapps/deleteModal.jsx`** — the trash/delete icon had no tooltip at all; wrapped it the same way with `t('global.delete')`.

### Touch devices
The same fix restores touch tooltips too — MUI attaches `onTouchStart`/`onTouchEnd` (long-press ~700ms) to the direct child, which was also being dropped through `PermissionGuard`. Tooltips now appear on long-press on mobile (stock MUI behavior, delays unchanged).

## Verification
- `npm run client-build` passes (vite build OK).
- Only the two `.jsx` source files change; static build assets are gitignored.
- Committed on a branch based on `upstream/unstable` (`49753241`).