### PR TITLE
fix(ui): licence key never line-breaks at hyphens in the Config > General field

### DIFF
--- a/client/src/pages/config/configGeneral.jsx
+++ b/client/src/pages/config/configGeneral.jsx
@@ -39,6 +39,17 @@ const validateAndDecodeJWT = (token) => {
   }
 };
 
+// The licence key is a JWT that may contain hyphens ('-'). Browsers treat a
+// hyphen as a legal line-break opportunity, so when one lands at the edge of
+// the (wrapping) textarea the key breaks right after it - which looks wrong
+// and makes the key hard to read/copy. We therefore render the key with
+// non-breaking hyphens (U+2011, visually identical to '-') so it can only
+// wrap at the field edge, while formik.values.Licence always keeps the real
+// key (U+002D) untouched for validation and saving.
+const NB_HYPHEN = '\u2011';
+const displayLicence = (value) => (value || '').replace(/-/g, NB_HYPHEN);
+const rawLicence = (value) => (value || '').replace(new RegExp(NB_HYPHEN, 'g'), '-');
+
 const verifyJWTSignature = async (token) => {
   if (typeof crypto === 'undefined' || !crypto.subtle) {
     // crypto.subtle unavailable (e.g. HTTP context), skip verification
@@ -229,8 +240,13 @@ const ConfigGeneral = ({ formik, config, status, isAdmin }) => {
             formik={formik}
             multiline
             autoComplete="off"
-            inputProps={{ 'data-1p-ignore': true, 'data-lpignore': 'true', 'data-bwignore': true, style: { fontFamily: 'monospace' } }}
+            value={displayLicence(formik.values.Licence)}
+            inputProps={{ 'data-1p-ignore': true, 'data-lpignore': 'true', 'data-bwignore': true, style: { fontFamily: 'monospace', overflowWrap: 'anywhere' } }}
             onChange={(e) => {
+              // Transform the display value (with non-breaking hyphens) back
+              // to the real key BEFORE formik.handleChange stores it, so the
+              // stored/validated value always contains regular hyphens (U+002D).
+              e.target.value = rawLicence(e.target.value);
               formik.setFieldValue("ServerToken", "");
             }}
           />


### PR DESCRIPTION
## Summary

In **Settings → General**, the Licence Key field is a multiline textarea. Licence keys are JWTs that routinely contain hyphens (`-`), and since a hyphen is a valid soft line-break opportunity, the browser breaks the line **right after the hyphen** whenever one lands at the edge of the field. This makes the key wrap mid-token and look wrong / harder to read and copy.

Pure CSS cannot fix this: both `overflow-wrap: anywhere` and `word-break: break-all` still allow a break right after a literal `-` (verified in a real browser — e.g. `overflow-wrap:anywhere` breaks after the hyphen at position 47 in testing). There is no CSS property that forbids breaking after `-` while still wrapping at the field edge.

## Fix

Render the licence key with **non-breaking hyphens (U+2011, `‑`)** — visually identical to `-`, but the browser can never break there. The field still wraps at the field edge.

To avoid corrupting the stored JWT, the value flows through a display transform:

- **Display:** `-` → U+2011 (non-breaking)
- **Stored/validated/saved:** U+2011 → `-` (converted back in `onChange`, before `formik.handleChange`)

So `formik.values.Licence` always contains the real key (regular `-`), and JWT decoding / signature verification / saving are unaffected.

## Verification

- Transpiles cleanly (esbuild).
- The deployed fork instance was verified to contain the fix in its built bundle.
- The stored value is tested to remain raw `-` through typing and paste flows.