### PR TITLE
fix(ui): correct container log timestamp extraction & timezone (dedup)

### DIFF
--- a/client/src/components/logLine.jsx
+++ b/client/src/components/logLine.jsx
@@ -44,16 +44,34 @@ const LogLine = ({ message, docker, isMobile }) => {
   html += '</span>'.repeat(colorStack.length);
 
   if (docker) {
-    let parts = html.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z/);
+    // Docker prefixes every log line with a UTC RFC3339 timestamp (e.g. 2026-09-07T08:07:46.123456789Z),
+    // followed by a space, then the container's own stdout/stderr. Some containers re-print their own
+    // local timestamp right after that prefix (e.g. "2026-09-07 10:07:45.720 CEST ..."). The timestamp
+    // regex is anchored to the start of the line so we always extract the Docker UTC prefix, and any
+    // timestamp the container printed itself is removed from the body to avoid duplicating it.
+    let parts = html.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z/);
     if (!parts) {
       return <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }} />;
     }
-    let restString = html.replace(parts[0], '');
-   
+    // Convert the Docker UTC timestamp to the viewer's local timezone for display.
+    let ts = parts[0].replace(/\.(\d{3})\d+Z/, '.$1Z'); // JS Date only handles ms precision
+    let localDate = new Date(ts);
+    const pad2 = (n) => String(n).padStart(2, '0');
+    const formatted = isNaN(localDate.getTime())
+      ? parts[0].replace('T', ' ').split('.')[0]  // fall back to raw UTC
+      : `${localDate.getFullYear()}-${pad2(localDate.getMonth() + 1)}-${pad2(localDate.getDate())} ${pad2(localDate.getHours())}:${pad2(localDate.getMinutes())}:${pad2(localDate.getSeconds())}`;
+
+    // Remove the Docker prefix, then any timestamp the container printed itself right after it
+    // (e.g. "2026-09-07 10:07:45.720 CEST" or "... +02:00") so it does not appear twice.
+    let restString = html.replace(parts[0], '')
+      .replace(/^&nbsp;/, '')
+      .replace(/^(?:<span[^>]*>)*\[?\d{4}(?:-|\/)\d{2}(?:-|\/)\d{2}(?:T|&nbsp;)\d{2}:\d{2}:\d{2}(?:[.,]\d{1,9})?(?:Z|[+-]\d{2}:?\d{2})?(?:&nbsp;(?:[A-Z]{2,6}|[+-]\d{2}:?\d{2}|Z))?\]?(?:<\/span>)*(?:&nbsp;+|<br>|$)/, '')
+      .replace(/^&nbsp;(?=(?:&nbsp;)*[A-Z\[])/, '');
+
     return (
       <Stack direction={isMobile ? 'column' : 'row'} spacing={1} alignItems="flex-start">
         <div style={{color:'#AAAAFF', fontStyle:'italic', whiteSpace: 'pre', background: '#393f48', padding: '0 0.5em', marginRight: '5px'}}>
-          {parts[0].replace('T', ' ').split('.')[0]}
+          {formatted}
         </div>
         <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(restString) }} />
       </Stack>


### PR DESCRIPTION
## What & why

Container logs in the ServApps UI show **duplicated, wrong-timezone timestamps** for many containers.

`api_getlogs.go` requests logs with `Timestamps: true`, so Docker prefixes **every** line with a UTC RFC3339 timestamp (e.g. `2026-09-07T08:07:46.123456789Z `) before the container's own output. `LogLine`'s docker branch used an **unanchored** regex to pick a timestamp out of the line, so when a container also printed its own timestamp, the **raw UTC prefix stayed in the message body** while the pill showed UTC (wrong timezone) — producing a duplicated timestamp.

## The fix (`client/src/components/logLine.jsx`)

1. **Anchor** the timestamp regex to the start of the line so we always extract Docker's UTC prefix.
2. **Convert** that UTC timestamp to the **viewer's local timezone** for the pill instead of raw UTC.
3. **Strip a timestamp the container printed right after the prefix**, covering widely used formats:
   - space- or `T`-separated dates, dash or **slash** separators
   - `.` or `,` fractional seconds (Python logging, .NET/Java, Rust)
   - timezones: named (`CEST`/`UTC`), numeric `+02:00` / `+0200`, `Z` (attached or spaced), bracketed `[ts]`
   - **ANSI color `<span>` wrappers** around the timestamp (LiteLLM, FileBrowser, Wealthfolio, NZBHydra, Navidrome)
   - separators: `&nbsp;`, `<br>` (container wrote `\r`), or end-of-line
   - collapses leftover leading whitespace but **preserves genuine indentation** on continuation lines (e.g. `.NET` stack traces)

## Verification

Tested against: LiteLLM, FileBrowser, Wealthfolio, NZBHydra, jackett, granian, searx, Rust `tracing-subscriber`, npm SPA (slash-date), SQLite CEST, Spring/NZBHydra multi-space, plurality, Navidrome `time=`, `.NET` stack-trace indentation (kept), plus no-/mid-line date false positives. `npm run client-build` passes.

All previous WIP commits were squashed into this single clean commit.