### PR TITLE
fix: store admin email during stepped new install setup

### DIFF
--- a/src/newInstall.go
+++ b/src/newInstall.go
@@ -20,7 +20,7 @@ type NewInstallJSON struct {
 	TLSKey string `json:"tlsKey"`
 	Nickname string `json:"nickname"`
 	Password string `json:"password"`
-	Email string `json:"omitempty,email"`
+	Email string `json:"email,omitempty"`
 	Hostname string `json:"hostname"`
 	Step string `json:"step"`
 	SSLEmail string `json:"sslEmail",validate:"omitempty,email"`


### PR DESCRIPTION
## Summary

The stepped setup wizard (`/api/newInstall`, step 4) creates the first admin user without its email address. The account is created (role, password hash, timestamps persist), but `users.email` is left empty — which breaks password-reset emails, login notifications and invites for that first user.

## Root cause

`NewInstallJSON.Email` is declared with the JSON struct-tag option *before* the field name:

```go
Email string `json:"omitempty,email"`
```

Go&#39;s `encoding/json` parses struct tags as `<name>,<option>`. With `omitempty,email`, the decoder treats `omitempty` as the **field name** and `email` as the option, so the client-sent `"email"` key never matches. The field stays at its zero value `""` and the email is silently dropped on insert.

The one-shot `SetupRoute` uses the correct ordering (`SetupJSON.Email` = `json:"email,omitempty"`) and stores the email correctly, which is why only the wizard path is affected.

## Fix

One-line tag swap to the correct order:

```diff
- Email string `json:"omitempty,email"`
+ Email string `json:"email,omitempty"`
```

This is the only occurrence of the option-before-name pattern in the codebase.

## Verification

Built the server (go1.26, CGO=0), ran it in a scratch config dir, and walked the real UI flow via the API:

- `/api/newInstall` step 4 (wizard): sent `carol@example.com` → stored as empty string (bug)
- `/api/setup` (one-shot): sent `bob@test.com` → stored correctly

After the fix, step 4 stores the email correctly.

## Impact

- Server component only, one line.
- No migration needed — it only affects newly created users going forward.